### PR TITLE
ドメインを`.net`に変更

### DIFF
--- a/api/config/initializers/cors.rb
+++ b/api/config/initializers/cors.rb
@@ -7,7 +7,7 @@
 
 Rails.application.config.middleware.insert_before 0, Rack::Cors do
   allow do
-    origins ENV['FRONT_DOMAIN'], 'company-ranking.jp', 'company-ranking.netlify.app'
+    origins ENV['FRONT_DOMAIN'], 'company-ranking.net', 'company-ranking.netlify.app'
 
     resource '*',
       headers: :any,

--- a/api/heroku.yml
+++ b/api/heroku.yml
@@ -8,7 +8,7 @@ setup:
     RAILS_LOG_TO_STDOUT: enabled
     RAILS_SERVE_STATIC_FILES: enabled
     # FRONT_DOMAIN: boring-kilby-a479eb.netlify.app for practive
-    FRONT_DOMAIN: 'company-ranking.jp'
+    FRONT_DOMAIN: 'company-ranking.net'
     WORKDIR: myapp
     PROJECT_PATH: api
 build:


### PR DESCRIPTION
.jpドメインはNetlify CDNを利用できないため