### PR TITLE
Fix missing null check for getLocale() return value in middleware redirect

### DIFF
--- a/typescript/middleware.ts
+++ b/typescript/middleware.ts
@@ -45,7 +45,7 @@ export function middleware(request: NextRequest) {
 
   // Redirect if there is no locale
   if (pathnameIsMissingLocale) {
-    const locale = getLocale(request)
+    const locale = getLocale(request) || i18n.defaultLocale
 
     // e.g. incoming request is /products
     // The new URL is now /en-US/products


### PR DESCRIPTION
## Bug Description

The `getLocale()` function returns `string | undefined`, but when `pathnameIsMissingLocale` is true, the code uses the `locale` variable directly in URL construction without checking if it's undefined. This causes a runtime error when no valid locale can be determined from the request headers.

## Fix

Added a fallback to `i18n.defaultLocale` when `getLocale(request)` returns `undefined`:

```typescript
const locale = getLocale(request) || i18n.defaultLocale
```

This ensures that the middleware always has a valid locale to use for redirecting requests, preventing runtime errors.

---

*This PR was generated by [PRJanitor](https://prjanitor.com) — an automated tool that finds and fixes small bugs in open-source projects.*

We respect your contribution guidelines — if your project doesn't accept bot PRs, we won't send more. You can also add a `.github/prjanitor.yml` file with `enabled: false` to opt out explicitly.