### PR TITLE
Add specification for MAU 1000 roadmap

### DIFF
--- a/.specify/feature.json
+++ b/.specify/feature.json
@@ -1,0 +1,3 @@
+{
+  "feature_directory": "specs/001-mau-1000-roadmap"
+}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -66,6 +66,10 @@ make go/generate/models  # xo schema → go/models/*.xo.go (do not edit *.xo.go 
 - **External services**: this codebase already integrates with EDINET, JPX scraping, Slack webhooks, GCP (Cloud Build / Terraform), and Supabase. Adding a *new* third-party service may require an internal "External Service Review" — flag it to the user first.
 
 <!-- SPECKIT START -->
-For additional context about technologies to be used, project structure,
-shell commands, and other important information, read the current plan
+Active Spec Kit feature: `001-mau-1000-roadmap` — MAU を約 100 → 1,000 に拡大する 3 ヶ月ロードマップ。
+- Plan: [specs/001-mau-1000-roadmap/plan.md](specs/001-mau-1000-roadmap/plan.md)
+- Spec: [specs/001-mau-1000-roadmap/spec.md](specs/001-mau-1000-roadmap/spec.md)
+- Phase 0 (research): [specs/001-mau-1000-roadmap/research.md](specs/001-mau-1000-roadmap/research.md)
+- Phase 1 (data model + contracts): [specs/001-mau-1000-roadmap/data-model.md](specs/001-mau-1000-roadmap/data-model.md), [specs/001-mau-1000-roadmap/contracts/](specs/001-mau-1000-roadmap/contracts/)
+- Quickstart: [specs/001-mau-1000-roadmap/quickstart.md](specs/001-mau-1000-roadmap/quickstart.md)
 <!-- SPECKIT END -->

--- a/specs/001-mau-1000-roadmap/checklists/requirements.md
+++ b/specs/001-mau-1000-roadmap/checklists/requirements.md
@@ -1,0 +1,45 @@
+# Specification Quality Checklist: MAU 1000 達成ロードマップ
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2026-05-11
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+## Notes
+
+### Validation observations
+
+- 仕様は元の roadmap ドキュメントを基に技術中立な要件・成功基準に再構成済み。
+- 以下の点は意図的に実装詳細寄りで残している(ユーザーが既に技術スタックを確定済みのため):
+  - sitemap / robots / hreflang / JSON-LD などの SEO 用語(Web の業界標準語彙、技術非依存)
+  - GA4 / GSC / Lighthouse(計測ツール固有名だが、本機能の目的が「これらの指標を改善する」ものであるため不可避)
+  - URL パスパターン(`/{lang}/rankings/{slug}` など)は計画で確定済みの URL 設計を要件に固定する目的で残置
+- 以下のエリアでは reasonable defaults を採用し、`Assumptions` に明記:
+  - MAU の定義(GA4 デフォルト 28 日 ではなく engagement filter 適用後の値)
+  - 言語別 MAU 内訳(日本語 ~950 / 英語 ~50)
+  - 1 人体制の運用工数(15h/週)
+- `[NEEDS CLARIFICATION]` マーカーはゼロ。残課題は `/speckit-clarify` ではなく `/speckit-plan` での技術設計判断に委ねる。

--- a/specs/001-mau-1000-roadmap/contracts/sitemap-shape.md
+++ b/specs/001-mau-1000-roadmap/contracts/sitemap-shape.md
@@ -1,0 +1,167 @@
+# Contract: sitemap.xml の形
+
+**Feature**: 001-mau-1000-roadmap
+**Purpose**: `app/sitemap.ts` が返す `MetadataRoute.Sitemap` 配列の各エントリの値の決定ルールを固定する。
+
+---
+
+## 1. ファイル位置
+
+- 単一ファイル: `typescript/app/sitemap.ts`
+- 公開 URL: `https://www.company-ranking.net/sitemap.xml`
+- `export const revalidate = 86400`(24 時間で再生成)
+
+URL 数が 10,000 を超えた段階で `generateSitemaps` API を使い `sitemap-{group}.xml` 形式に分割(FR-026)。分割閾値到達は Phase 3 後半の見込み。
+
+---
+
+## 2. エントリ型
+
+Next.js 標準型をそのまま使う:
+
+```ts
+// from next/dist/lib/metadata/types/metadata-interface
+type SitemapEntry = {
+  url: string;                              // 絶対 URL、末尾スラッシュなし
+  lastModified?: string | Date;
+  changeFrequency?: "always" | "hourly" | "daily" | "weekly" | "monthly" | "yearly" | "never";
+  priority?: number;                        // 0.0 – 1.0
+  alternates?: {
+    languages?: Record<string, string>;     // BCP47 言語コード → URL
+  };
+};
+```
+
+`alternates.languages` のキーは `ja`(or `ja-JP`)と `en`(or `en-US`)を採用。Google は どちらでも解釈する。
+
+---
+
+## 3. URL 種類ごとの値
+
+`BASE = https://www.company-ranking.net`
+
+### 3.1 静的ページ
+
+| `url` | `lastModified` | `changeFrequency` | `priority` | `alternates.languages` |
+|-------|----------------|--------------------|-----------|----------------------|
+| `BASE/ja` | (ビルド日) | `weekly` | `1.0` | `{ ja: BASE/ja, en: BASE/en }` |
+| `BASE/en` | 同上 | 同上 | 同上 | 同上 |
+| `BASE/ja/companies` | (ビルド日) | `weekly` | `0.8` | `{ ja: BASE/ja/companies, en: BASE/en/companies }` |
+| `BASE/en/companies` | 同上 | 同上 | 同上 | 同上 |
+| `BASE/ja/contact` | (ビルド日) | `yearly` | `0.3` | 両方 |
+| `BASE/en/contact` | 同上 | 同上 | 同上 | 両方 |
+| `BASE/ja/terms_of_use` | (ビルド日) | `yearly` | `0.3` | 両方 |
+| `BASE/en/terms_of_use` | 同上 | 同上 | 同上 | 両方 |
+
+### 3.2 企業詳細(動的)
+
+```
+url:                BASE/[lang]/companies/[id]
+lastModified:       Company.dataUpdatedAt(なければビルド日)
+changeFrequency:    "monthly"
+priority:           0.6
+alternates.languages: { ja: BASE/ja/companies/[id], en: BASE/en/companies/[id] }
+```
+
+- 取得元: `listSecurityCodes()` を 1 回呼んで全企業 ID を取得 → ロケール 2 倍展開
+- **soft-404 防止**(FR-007b): `listSecurityCodes` が返さない ID は含めない
+
+### 3.3 業界詳細 + 並び順タブ
+
+```
+# デフォルト(net_sales)
+url:                BASE/[lang]/industries/[id]
+lastModified:       (ビルド日)
+changeFrequency:    "weekly"
+priority:           0.7
+
+# 並び順タブ 3 種(salary / op-income / equity)
+url:                BASE/[lang]/industries/[id]/[sortType]
+lastModified:       (ビルド日)
+changeFrequency:    "weekly"
+priority:           0.6
+```
+
+各エントリに `alternates.languages` を付与。
+
+### 3.4 市場詳細 + 並び順タブ
+
+業界と同じ形式。
+
+### 3.5 業界 overview(Phase 4)
+
+```
+url:                BASE/[lang]/industries/[id]/overview
+lastModified:       (ビルド日)
+changeFrequency:    "monthly"
+priority:           0.7
+```
+
+### 3.6 ランキングハブ
+
+```
+url:                BASE/[lang]/rankings/[slug]
+lastModified:       (ビルド日)
+changeFrequency:    "weekly"
+priority:           0.7
+alternates.languages: 英語版が未提供のものは ja のみ(出さない方が hreflang クラスタの誤検出を防げる)
+```
+
+### 3.7 比較ページ(prebuilt のみ)
+
+```
+url:                BASE/[lang]/compare/[idA]/[idB]
+lastModified:       (ビルド日)
+changeFrequency:    "monthly"
+priority:           0.4
+```
+
+- 上位 200 ペア(`generateStaticParams` 範囲)のみ sitemap に含める
+- on-demand ISR の動的生成ペアは sitemap には載せない(クロール優先度を上げる必要がないため)
+
+---
+
+## 4. 出力規模見積もり
+
+| カテゴリ | エントリ数 |
+|----------|-----------|
+| 静的 | 8 |
+| 企業詳細 × 2 ロケール | ~6,000 |
+| 業界(default + 3 sort) × 33 業界 × 2 ロケール | 264 |
+| 市場(default + 3 sort) × 主要市場 ~10 × 2 ロケール | 80 |
+| 業界 overview × 33 × 2 ロケール | 66(Phase 4) |
+| ランキングハブ JA | 20–30(P3) → 80–100(P4) |
+| ランキングハブ EN | 0(未提供) |
+| 比較 × 2 ロケール | 400 |
+| **合計** | **~7,000 → ~7,200 → ~7,300** |
+
+50,000 URL 上限の単一 sitemap で十分。10,000 を超えるのは P4 完了後の拡張時。
+
+---
+
+## 5. キャッシュ / 鮮度
+
+- `revalidate = 86400` で日次再生成
+- 企業データ更新(Ruby バッチ実行)後の sitemap 鮮度遅延は最大 24h
+- GSC への手動再提出は不要(URL 自体に変化はなく、`lastmod` が変わる程度)
+
+---
+
+## 6. 検証
+
+`quickstart.md` の Phase 1 セクションで以下を確認:
+
+```bash
+# 1. sitemap が 200 OK で返る
+curl -I https://www.company-ranking.net/sitemap.xml
+
+# 2. エントリ数が想定通り(~7,000)
+curl -s https://www.company-ranking.net/sitemap.xml | grep -c "<loc>"
+
+# 3. hreflang alternates が含まれている
+curl -s https://www.company-ranking.net/sitemap.xml | grep -c "xhtml:link"
+
+# 4. ローカルビルドで生成できる
+docker compose run --rm typescript npm run build && \
+  ls typescript/.next/server/app/sitemap.xml
+```

--- a/specs/001-mau-1000-roadmap/contracts/url-routes.md
+++ b/specs/001-mau-1000-roadmap/contracts/url-routes.md
@@ -1,0 +1,117 @@
+# Contract: URL Routes
+
+**Feature**: 001-mau-1000-roadmap
+**Purpose**: 公開 URL の規約と canonical / hreflang 算出ルールを固定する。Phase 1 設計の入力であり、実装後の差分検証にも使う。
+
+---
+
+## 1. ルート一覧
+
+凡例: `[lang]` ∈ `{ja, en}`、`[id]` は数値、`[slug]` / `[sortType]` は別表参照。
+
+| 種類 | パターン | レンダリング | sitemap | canonical 規則 |
+|------|----------|-------------|---------|----------------|
+| ルート(JA 既定リダイレクト) | `/` | redirect → `/ja` | 含めない | n/a |
+| トップ | `/[lang]` | SSG + ISR(1h) | ✅ | self |
+| 企業リスト | `/[lang]/companies` | ISR(1h) | ✅ | self(クエリ無視) |
+| 企業詳細 | `/[lang]/companies/[id]` | SSG | ✅(現存 ID のみ) | self |
+| 業界詳細(default sort) | `/[lang]/industries/[id]` | ISR(1h) | ✅ | self |
+| 業界 sortType タブ | `/[lang]/industries/[id]/[sortType]` | ISR(1h) | ✅ | `[sortType]==net_sales` のときは `/[lang]/industries/[id]` を canonical |
+| 業界 overview(P4) | `/[lang]/industries/[id]/overview` | ISR(24h) | ✅ | self |
+| 市場詳細 | `/[lang]/markets/[id]` | ISR(1h) | ✅ | self |
+| 市場 sortType | `/[lang]/markets/[id]/[sortType]` | ISR(1h) | ✅ | 上記同様 |
+| ランキングハブ | `/[lang]/rankings/[slug]` | SSG + ISR(24h) | ✅ | self |
+| 比較ページ | `/[lang]/compare/[idA]/[idB]` | 上位 200 ペア SSG / 残り on-demand ISR | ✅(prebuilt 分のみ) | self(`idA < idB` に正規化) |
+| お問い合わせ / 利用規約 | `/[lang]/contact`, `/[lang]/terms_of_use` | SSG | ✅ | self |
+| sitemap | `/sitemap.xml` | 動的(`app/sitemap.ts`、24h revalidate) | n/a | n/a |
+| robots | `/robots.txt` | 静的(`app/robots.ts`) | n/a | n/a |
+| OGP 動的画像 | `/[lang]/.../opengraph-image` | Edge Runtime(オンデマンド + CDN) | 含めない | n/a |
+
+## 2. 並び順 sortType の語彙
+
+| URL slug | データ列 | デフォルト |
+|----------|---------|-----------|
+| (未指定) | `Company.netSales` desc | ✅ |
+| `salary` | `Company.averageAnnualSalary` desc | |
+| `op-income` | `Company.operatingIncome` desc | |
+| `equity` | `Company.equityToAssetRatio` desc | |
+
+`generateStaticParams` で上記 4 種に限定列挙。それ以外は `notFound()`。
+
+## 3. ランキングハブ slug の語彙(Phase 3 初期)
+
+| slug | sortType | filter | 想定タイトル(JA) |
+|------|----------|--------|------------------|
+| `nensyu` | salary | - | 日本企業 平均年収ランキング |
+| `uriage` | net_sales | - | 売上高ランキング |
+| `eigyou-rieki` | op-income | - | 営業利益ランキング |
+| `roe` | (custom: ROE 列) | - | ROE ランキング |
+| `nensyu/{industry-slug}` | salary | industryId | {業界名} 平均年収ランキング |
+| `uriage/{industry-slug}` | net_sales | industryId | {業界名} 売上高ランキング |
+
+`industry-slug` は `dictionaries/{lang}.json` の `industrySlug` テーブルで管理(例: 銀行業 → `ginkougyou`)。
+
+## 4. canonical 算出
+
+```
+canonical(path, lang) := https://www.company-ranking.net{path}
+```
+
+- 末尾 `/` はつけない
+- `?` 以降は除外(クエリストリングをカノニカルに含めない)
+- sortType デフォルト(`net_sales`)はパスから sortType セグメントを除いた URL を canonical
+- 比較ページは `idA < idB` の順序に正規化した URL を canonical
+
+## 5. hreflang 算出
+
+```
+hreflang(path) := {
+  "ja-JP":     https://www.company-ranking.net/ja{relativePath}
+  "en-US":     https://www.company-ranking.net/en{relativePath}
+  "x-default": (= ja-JP のもの)
+}
+```
+
+`relativePath` はパスから `/[lang]` プレフィクスを除いたもの。
+
+英語版コンテンツが存在しないハブ・比較・overview ページは:
+
+- 該当英語パスが 404 を返すならば `<link rel="alternate" hreflang="en-US">` を **出力しない**(Google の hreflang クラスタ無効化を防ぐ)
+- それ以外は両方を出力
+
+## 6. og:locale
+
+| `[lang]` | `og:locale` |
+|----------|-------------|
+| `ja` | `ja_JP` |
+| `en` | `en_US` |
+
+`app/[lang]/layout.tsx` で動的に切替(現状のハードコード `ja_JP` は FR-003 に違反)。
+
+## 7. robots.txt の設計
+
+```
+User-agent: *
+Allow: /
+Disallow: /*?q=*
+Disallow: /*?sortType=*
+
+Sitemap: https://www.company-ranking.net/sitemap.xml
+```
+
+**注意**: `?sortType=*` Disallow があるため、並び順タブは **path segment** で実装する(クエリパラメータ不採用)。`/*opengraph-image*` は Allow のままでよい(Google にとって有用)。
+
+## 8. 削除済み URL の扱い
+
+- 企業 ID が存在しない: `notFound()` → HTTP 404、`<head>` に `<meta name="robots" content="noindex">`、sitemap からも除外
+- 不正な sortType / hub slug: `generateStaticParams` で限定済み + `notFound()`
+- リダイレクトが必要なケース(例: 旧 URL → 新 URL): 現時点では発生しない設計。将来必要なら `next.config.mjs` の `redirects()` を使う(別チケット)
+
+## 9. このコントラクトの検証方法
+
+`quickstart.md` の Phase 1 検証セクションで以下を確認する:
+
+1. `curl https://www.company-ranking.net/sitemap.xml` で URL が表に従って列挙されること
+2. `curl -I /ja/companies/{存在しないID}` が **HTTP 404** を返すこと(soft-404 でないこと)
+3. `curl /ja/industries/{id}` のレスポンス HTML に `<link rel="canonical" href="https://www.company-ranking.net/ja/industries/{id}">` と `<link rel="alternate" hreflang="ja-JP" ...>` が含まれること
+4. `curl /ja/industries/{id}/salary` の HTML の canonical が `/ja/industries/{id}/salary` を指していること(non-default のため self が canonical)

--- a/specs/001-mau-1000-roadmap/data-model.md
+++ b/specs/001-mau-1000-roadmap/data-model.md
@@ -1,0 +1,226 @@
+# Phase 1 Data Model: MAU 1000 達成ロードマップ
+
+**Feature**: 001-mau-1000-roadmap
+**Date**: 2026-05-11
+**Source**: spec.md "Key Entities" + 既存 OpenAPI client 型(`typescript/client/**`、編集禁止)
+
+このフィーチャーは新規 DB スキーマや新規 API を導入しない。本ドキュメントは「フロントエンドが取り回す概念モデル」として、既存 API レスポンスをどの ViewModel に詰め直すかを示す。
+
+---
+
+## 1. Company(企業)
+
+**Source**: 生成済み client の `Company` 型 + `getCompany` レスポンス。
+
+| Field | Type | 用途 |
+|-------|------|------|
+| `id` | `number` | 証券コード相当(URL の `[id]`)|
+| `name` | `string` | H1、`<title>`、JSON-LD `Corporation.name`、OGP |
+| `industryId` | `number` | 関連企業セクション、ハブのフィルタ |
+| `marketId` | `number` | 関連企業セクション |
+| `headOfficeLocation` | `string` | JSON-LD `Corporation.address` |
+| `numberOfEmployees` | `number \| null` | JSON-LD `Corporation.numberOfEmployees`、OGP |
+| `netSales` | `number \| null` | ランキング、関連企業セクション、ファクトイド |
+| `lastYearNetSales` | `number \| null` | YoY 成長率(ファクトイド・ハブ コメンタリ) |
+| `operatingIncome` | `number \| null` | 並び順タブ |
+| `averageAnnualSalary` | `number \| null` | 並び順タブ・年収ランキングハブ |
+| `equityToAssetRatio` | `number \| null` | 並び順タブ |
+| `roe` | `number \| null` | ROE ランキングハブ |
+| `fiscalYear` | `string`(例: `"FY2024"`)| データ更新日バッジ(FR-014a)|
+| `dataUpdatedAt` | `Date` | データ更新日バッジ・sitemap `lastmod` |
+
+**Validation / Edge cases**:
+- `id` が DB に存在しない → `notFound()` を呼んで HTTP 404(FR-007b)
+- 数値フィールドが `null`(未開示)の場合、ランキング・並び順タブ では除外する
+- `dataUpdatedAt` が取れない場合はビルド日にフォールバック(コメント警告を出す)
+
+**ViewModel**: `app/[lang]/companies/[id]/page.tsx` で `Company` を取得し、関連企業向けに `RelatedCompaniesViewModel`(industry TOP5 + market TOP5 ペア)に派生させる。
+
+---
+
+## 2. Industry(業界)
+
+**Source**: 生成済み client の `Industry` 型 + `listIndustries`。
+
+| Field | Type | 用途 |
+|-------|------|------|
+| `id` | `number` | URL の `[id]` |
+| `nameJa` | `string` | 日本語ページの H1 / `<title>` / JSON-LD |
+| `nameEn` | `string` | 英語ページの同上 |
+| `companyCount` | `number`(派生)| ハブコメンタリ「{業界} 全 {N} 社中」 |
+
+**Relationships**: `Industry` 1 — N `Company`(`Company.industryId` で参照)。
+
+**State**: 33 業界で固定。spec の対象会計年度内では新規追加・削除はないと仮定する(EDINET 区分の異動は年に数件以下)。
+
+---
+
+## 3. Market(市場)
+
+**Source**: 生成済み client の `Market` 型 + `listMarkets`。
+
+| Field | Type | 用途 |
+|-------|------|------|
+| `id` | `number` | URL の `[id]` |
+| `nameJa` / `nameEn` | `string` | H1 / `<title>` |
+| `companyCount` | `number`(派生) | ハブコメンタリ |
+
+**Relationships**: `Market` 1 — N `Company`(`Company.marketId` で参照)。
+
+---
+
+## 4. SortType(並び順)
+
+**Source**: 新規(クライアント側のみで定義)。
+
+```ts
+// typescript/lib/sort-type.ts に定義予定
+export const SORT_TYPES = ["net_sales", "salary", "op-income", "equity"] as const;
+export type SortType = typeof SORT_TYPES[number];
+```
+
+| `slug` | データ列 | デフォルトか |
+|--------|---------|-------------|
+| `net_sales` | `Company.netSales` desc | ✅ デフォルト(URL では省略可) |
+| `salary` | `Company.averageAnnualSalary` desc | |
+| `op-income` | `Company.operatingIncome` desc | |
+| `equity` | `Company.equityToAssetRatio` desc | |
+
+**Validation**: 上記 4 値以外の slug が来た場合 `notFound()`。`generateStaticParams` で限定列挙する。
+
+**`<title>` 表現**(`dictionaries/{lang}.json`):
+
+```json
+{ "sortType": { "salary": "平均年収", "op-income": "営業利益", "equity": "自己資本比率" } }
+```
+
+---
+
+## 5. RankingHub(ランキングハブ)
+
+**Source**: 新規(`typescript/lib/ranking-hubs.ts` の静的マップ)。
+
+```ts
+type RankingHubSlug = "nensyu" | "uriage" | "eigyou-rieki" | "roe" | string;
+
+interface RankingHub {
+  slug: RankingHubSlug;
+  sortType: SortType;
+  industryId?: number;        // クロス業界ハブの場合
+  marketId?: number;
+  titleJa: string;            // 例: "日本企業 平均年収ランキング 2026"
+  introJa: string;            // 200–400 字の固定導入文
+  topNCompanies: number;      // 既定 50
+}
+```
+
+| 初期スラッグ(Phase 3 の 20–30) | sortType | フィルタ | 例タイトル |
+|---|---|---|---|
+| `nensyu` | salary | なし | 日本企業 平均年収ランキング |
+| `uriage` | net_sales | なし | 売上高ランキング |
+| `eigyou-rieki` | op-income | なし | 営業利益ランキング |
+| `roe` | (custom: roe) | なし | ROE ランキング |
+| `nensyu/jouhou-tsushin` | salary | industryId=情報通信 | 情報通信業 平均年収ランキング |
+| `nensyu/ginkougyou` | salary | industryId=銀行 | 銀行業 平均年収ランキング |
+| ...(主要 10 業界 × 2 指標) | | | |
+
+Phase 4 で 80–100 まで拡張(FR-024)。
+
+**Validation**: スラッグは静的マップに登録されたもの以外 `notFound()`。
+
+---
+
+## 6. SitemapEntry(sitemap.xml の 1 行)
+
+**Source**: 新規(`typescript/lib/sitemap-data.ts`)。Next.js の `MetadataRoute.Sitemap` 型に詰める。
+
+```ts
+interface SitemapEntry {
+  url: string;                                // 絶対 URL
+  lastModified: Date;                         // Company は dataUpdatedAt、それ以外はビルド日
+  changeFrequency: "monthly" | "weekly" | "yearly";
+  priority: number;                           // 0.1–1.0
+  alternates: { languages: { ja: string; en: string } };
+}
+```
+
+**生成ルール**(詳細は `contracts/sitemap-shape.md` 参照):
+
+| 種類 | URL パターン | priority | changeFrequency |
+|------|-------------|----------|-----------------|
+| トップ | `/{lang}` | 1.0 | weekly |
+| 企業リスト | `/{lang}/companies` | 0.8 | weekly |
+| 企業詳細 | `/{lang}/companies/{id}` | 0.6 | monthly |
+| 業界詳細(default) | `/{lang}/industries/{id}` | 0.7 | weekly |
+| 業界 sortType タブ | `/{lang}/industries/{id}/{sortType}` | 0.6 | weekly |
+| 業界 overview(Phase 4) | `/{lang}/industries/{id}/overview` | 0.7 | monthly |
+| 市場詳細 | `/{lang}/markets/{id}` | 0.7 | weekly |
+| 市場 sortType | `/{lang}/markets/{id}/{sortType}` | 0.6 | weekly |
+| ランキングハブ | `/{lang}/rankings/{slug}` | 0.7 | weekly |
+| 比較ページ(prebuilt) | `/{lang}/compare/{idA}/{idB}` | 0.4 | monthly |
+| 静的(contact / terms_of_use) | `/{lang}/contact` 他 | 0.3 | yearly |
+
+---
+
+## 7. DataFreshness(データ更新日バッジ)
+
+**Source**: `Company.fiscalYear` + `Company.dataUpdatedAt` の組。Industry/Market ページではそれぞれの所属 Company 群の `MAX(dataUpdatedAt)` を集約値として使う。
+
+```ts
+interface DataFreshness {
+  fiscalYear: string;     // "FY2024" など
+  updatedAt: Date;        // 表示は YYYY-MM-DD
+}
+```
+
+**配置**: H1 直下またはサイドバー先頭(FR-014a)。`<DataFreshnessBadge fiscalYear updatedAt />` 1 コンポーネントで全ページ統一。
+
+---
+
+## 8. Factoid(「今日の発見」)
+
+**Source**: 新規(`typescript/lib/factoids.ts`)。トップページ・各ハブで使い回せるようテンプレ関数として実装。
+
+```ts
+type Factoid =
+  | { kind: "max", metric: string, company: string, value: number, unit: string }
+  | { kind: "yoyTopGrower", company: string, growthPct: number }
+  | { kind: "industryShare", industry: string, top5SharePct: number };
+```
+
+ビルド時に決定論的に算出する(同日内は同じファクトイドが出る)。
+
+---
+
+## 9. URL canonical / hreflang(派生規則)
+
+エンティティではなく算出ルール。`typescript/lib/seo.ts` 内に集約:
+
+```ts
+function canonicalFor(path: string, lang: "ja" | "en"): URL;
+function hreflangAlternates(path: string): {
+  "ja-JP": string;
+  "en-US": string;
+  "x-default": string; // = ja
+};
+```
+
+- `x-default` は `ja` を指す(主要ターゲットが日本語のため)
+- 並び順タブのデフォルト(`net_sales`)は canonical を `/{lang}/industries/{id}` に統一
+
+---
+
+## 10. データ取得経路(まとめ)
+
+| ページ | 必要データ | 取得関数(既存) | レンダリング戦略 |
+|--------|-----------|------------------|-----------------|
+| `/{lang}` | 企業 TOP10、業界・市場一覧、ファクトイド | `listCompanies({ limit: 10 })` + `listIndustries` + `listMarkets` | SSG + `revalidate=3600` |
+| `/{lang}/companies` | 企業一覧 + ページング | `listCompanies` | ISR `revalidate=3600` |
+| `/{lang}/companies/[id]` | 企業詳細 + 関連企業 | `getCompany` + `listCompanies({ industryId })` + `listCompanies({ marketId })` | SSG(`generateStaticParams`)|
+| `/{lang}/industries/[id]` | 業界詳細 + 上位企業 | `listIndustries` + `listCompanies({ industryId })` | ISR `revalidate=3600` |
+| `/{lang}/industries/[id]/[sortType]` | 同上 + 並び順 | 同上 | ISR `revalidate=3600` |
+| `/{lang}/rankings/[slug]` | ハブ静的設定 + 上位企業 | `listCompanies` フィルタ済 | SSG + `revalidate=86400` |
+| `/{lang}/compare/[idA]/[idB]` | 2 社の詳細 | `getCompany` × 2 | 上位 200 ペア SSG + `dynamicParams` |
+| `app/sitemap.ts` | 全 ID 列挙 | `listSecurityCodes` + `listIndustries` + `listMarkets` | `revalidate=86400` |
+
+すべての取得は **生成済み client 経由**。`typescript/client/**` には触れない(Constitution III)。新規エンドポイントは追加しない(Constitution I)。

--- a/specs/001-mau-1000-roadmap/plan.md
+++ b/specs/001-mau-1000-roadmap/plan.md
@@ -1,0 +1,166 @@
+# Implementation Plan: MAU 1000 達成ロードマップ
+
+**Branch**: `001-mau-1000-roadmap` | **Date**: 2026-05-11 | **Spec**: [spec.md](./spec.md)
+**Input**: Feature specification from `/specs/001-mau-1000-roadmap/spec.md`
+
+## Summary
+
+Next.js 15 App Router フロントエンド (`typescript/`) に SEO 基盤(sitemap / robots / hreflang / canonical / 構造化データ / OGP)とコンテンツ拡充(関連企業セクション、並び順 path tabs、ランキングハブ、比較ページ、業界 overview)を加え、データ更新日表示・soft-404 防止・Core Web Vitals 維持を組み合わせて、3 ヶ月で実 MAU 約 100 → 1,000 を達成する。Go API・Ruby バッチ・OpenAPI 契約・PostgreSQL スキーマには変更を加えない(フロントエンド単独機能)。
+
+## Technical Context
+
+**Language/Version**: TypeScript 5.x / Node.js 20.x。Next.js 15 App Router(`typescript/`)
+**Primary Dependencies**: Next.js 15(Metadata API、`next/og` の `ImageResponse`、`MetadataRoute.Sitemap` / `Robots`)、React 19 RSC、生成済み TS API クライアント(`typescript/client/**`、編集禁止)、`@/hooks/GetData.ts`(既存ラッパ)、`@/hooks/GetDictionary.ts`(i18n)
+**Storage**: 既存 PostgreSQL を Go API 経由で読み取り(フロントエンドからは `NEXT_PUBLIC_API_URL` 越しに HTTP)。スキーマ変更なし
+**Testing**: TypeScript には自動ユニットテストなし(Constitution IV)。検証手段: `make typescript/lint` + `docker compose run --rm typescript npm run build` + 手動ブラウザ確認(主要ページのリストを PR 本文に明記)
+**Target Platform**: 本番 Vercel(Edge + Serverless)。ローカル開発は `docker compose up`
+**Project Type**: web frontend(monorepo の `typescript/` のみ)
+**Performance Goals**: Lighthouse SEO ≥ 95、Lighthouse Performance(mobile)≥ 80、LCP ≤ 2.5s、INP ≤ 200ms、CLS ≤ 0.1。実 MAU(GA4 engagement filter 適用)1,000 / 28 日
+**Constraints**: 新規外部サービス導入なし(Constitution V)。OpenAPI 変更なし(API 既存エンドポイントで完結)。生成コード(`typescript/client/**`)編集禁止(Constitution III)。1 人 × 約 15h/週の運用工数
+**Scale/Scope**: 初期 ~6,000 URL(約 3,000 企業 × 2 ロケール + 33 業界 + 市場 × 2 ロケール + 静的)。Phase 2 で並び順 path tab を 4 種展開 → ~25,000 URL 級。Phase 3-4 で 20–100 ランキングハブ + 上位 200 比較ペア + 業界 overview。最終的に 10,000 URL を超えた段階で sitemap index 化(FR-026)
+
+## Constitution Check
+
+*GATE: Must pass before Phase 0 research. Re-check after Phase 1 design.*
+
+| Principle | Evaluation | Status |
+|-----------|------------|--------|
+| I. OpenAPI Contract Is the Source of Truth | 既存エンドポイント(`listSecurityCodes` / `listCompanies` / `listIndustries` / `listMarkets` / `getCompany`)のみで完結。スキーマ変更なし。 | ✅ Pass |
+| II. Runtime Boundaries Are Fixed | 全変更は `typescript/` 配下。Ruby に HTTP 追加なし、Go にバッチ追加なし。 | ✅ Pass |
+| III. Generated Code Is Read-Only | `typescript/client/**` 編集なし。新規ラッパは `typescript/components/` `typescript/hooks/` `typescript/app/` のみ。 | ✅ Pass |
+| IV. Lint, Test, and Build Gates Per Touched Runtime | `make typescript/lint` + `npm run build` をマージ前提。PR 本文に手動確認したページを必ず列挙。 | ✅ Pass(運用ルールで担保) |
+| V. External Service Boundaries Are Explicit | 新規 3rd-party 導入なし。GA4 / GSC / Hatenablog / Qiita / X はすべて既存または読み取り専用観測手段。`next/og` の `ImageResponse` は Next.js 標準機能で外部サービスではない。 | ✅ Pass |
+
+**Initial gate**: 5/5 Pass、ブロッカーなし。Phase 1 設計後に再評価する(末尾 "Post-design Re-check" 参照)。
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/001-mau-1000-roadmap/
+├── spec.md                              # /speckit-specify output
+├── plan.md                              # This file (/speckit-plan output)
+├── research.md                          # Phase 0 output
+├── data-model.md                        # Phase 1 output
+├── quickstart.md                        # Phase 1 output(運用 / 検証手順)
+├── contracts/
+│   ├── url-routes.md                    # Phase 1: URL routing & path conventions
+│   └── sitemap-shape.md                 # Phase 1: sitemap.xml entry shape
+├── checklists/
+│   └── requirements.md                  # /speckit-specify quality checklist
+└── tasks.md                             # /speckit-tasks 出力(本コマンドでは未生成)
+```
+
+### Source Code (repository root)
+
+このフィーチャーは `typescript/` 配下のみ変更する。Go / Ruby / OpenAPI には触れない。
+
+```text
+typescript/
+├── app/
+│   ├── sitemap.ts                       # ★新規: MetadataRoute.Sitemap、~25k URL を返す
+│   ├── robots.ts                        # ★新規: MetadataRoute.Robots
+│   └── [lang]/
+│       ├── layout.tsx                   # ✏修正: og:locale 動的化、hreflang、JSON-LD Organization+WebSite
+│       ├── page.tsx                     # ✏修正: TOP10 ミニテーブル + ファクトイド + ハブティーザー
+│       ├── companies/
+│       │   ├── page.tsx                 # ✏修正: canonical+hreflang、ISR
+│       │   └── [id]/
+│       │       ├── page.tsx             # ✏修正: canonical+hreflang、JSON-LD、関連企業セクション、データ更新日、404 化
+│       │       └── opengraph-image.tsx  # ★新規: 動的 OGP
+│       ├── industries/
+│       │   └── [id]/
+│       │       ├── page.tsx             # ✏修正: canonical+hreflang、JSON-LD、ISR、データ更新日
+│       │       ├── [sortType]/page.tsx  # ★新規: 並び順 path-tab(net_sales/salary/op_income/equity)
+│       │       ├── overview/page.tsx    # ★新規(Phase 4): 1500 字深掘り
+│       │       └── opengraph-image.tsx  # ★新規
+│       ├── markets/
+│       │   └── [id]/
+│       │       ├── page.tsx             # ✏修正
+│       │       ├── [sortType]/page.tsx  # ★新規
+│       │       └── opengraph-image.tsx  # ★新規
+│       ├── rankings/
+│       │   └── [slug]/page.tsx          # ★新規(Phase 3): ランキングハブ
+│       └── compare/
+│           └── [idA]/[idB]/page.tsx     # ★新規(Phase 3): 2 社比較
+├── components/
+│   ├── RelatedCompanies.tsx             # ★新規: 同業界・同市場 TOP5
+│   ├── ShareButtons.tsx                 # ★新規: X / はてブ
+│   ├── DataFreshnessBadge.tsx           # ★新規: FY + 更新日
+│   ├── JsonLd.tsx                       # ★新規: 型安全な <script type="application/ld+json">
+│   ├── SortTypeTabs.tsx                 # ★新規: path-tab ナビ
+│   └── (既存) Header / Footer / BreadCrumbs / GoogleAnalytics
+├── lib/
+│   ├── seo.ts                           # ★新規: canonical/hreflang/og:locale ヘルパ
+│   ├── sitemap-data.ts                  # ★新規: sitemap.ts 用データ取得+整形
+│   ├── ranking-hubs.ts                  # ★新規: スラッグ→クエリ設定の静的マップ
+│   ├── og-image.tsx                     # ★新規: ImageResponse 共通レイアウト
+│   └── factoids.ts                      # ★新規: 「今日の発見」生成
+├── hooks/
+│   └── (既存 GetData / GetDictionary を再利用、編集なし想定)
+├── client/                              # ⛔ 編集禁止(Constitution III)
+└── public/og/
+    ├── default-ja.png                   # ★新規: 静的 OGP(Top 等)
+    └── default-en.png                   # ★新規
+
+CLAUDE.md                                 # ✏修正: SPECKIT START/END に plan.md パスを差込
+```
+
+**Structure Decision**: 既存の Next.js 15 App Router ディレクトリ構成(`typescript/app/[lang]/...`)を維持しながら、横断ロジックは `typescript/lib/` に新規切り出す(Next.js では特別な意味を持たない通常のモジュールフォルダ)。生成コード `typescript/client/**` には触れず、すべて `app/` `components/` `lib/` `hooks/` `public/` のみで完結させる。`sitemap.ts` と `robots.ts` は App Router 規約上 `typescript/app/` 直下に置く必要があるため、ロケール `[lang]` 配下ではなくルートに配置する(両ロケール分の URL を 1 ファイルで生成)。
+
+## Phase 0: Outline & Research
+
+詳細は [research.md](./research.md) を参照。主な決定事項:
+
+- **sitemap 生成方式**: Next.js Metadata Routes(`app/sitemap.ts`)を採用。動的 sitemap index への切替は URL 数が 10,000 を超えた時点で `generateSitemaps` API に移行(FR-026)
+- **OGP 画像生成**: `next/og` の `ImageResponse`(Edge Runtime)を採用。外部サービス不要(Constitution V 適合)
+- **構造化データ実装**: 軽量な `<script type="application/ld+json">` インラインを採用(専用ライブラリ非導入)。型は `schema-dts` 互換の自前定義
+- **並び順タブの URL 設計**: path segment(`/{lang}/industries/{id}/{sortType}`)を採用、query string は不採用(robots Disallow との衝突回避、FR-002 / FR-012 整合)
+- **比較ページの事前生成範囲**: 上位 200 ペアのみ `generateStaticParams`、それ以外は `dynamicParams: true` + ISR。全組み合わせ約 4.5M ペアを事前生成しないことでビルド時間を制御
+- **404 / soft-404 戦略**: 存在しない企業 ID には `notFound()` を呼び、Next.js 標準 404 を返す。並行して sitemap 出力時にも対象 URL を除外
+- **データ更新日の取得元**: 既存 `getCompany` レスポンスに含まれる会計年度 / `updated_at`(なければ最新の document の `submitted_at` を使う)を表示。新規 API 追加は不要
+
+## Phase 1: Design & Contracts
+
+### 主要成果物
+
+1. **Data model**: [data-model.md](./data-model.md) — Company / Industry / Market / RankingHub / SortType / SitemapEntry / DataFreshness の構造と関係を整理
+2. **Interface contracts**: フロントエンド単独機能のため新規 HTTP API なし。代わりに以下を文書化:
+   - [contracts/url-routes.md](./contracts/url-routes.md) — 全公開 URL の規約(path 構造、canonical 算出ルール、hreflang 対応表、sortType 値の語彙)
+   - [contracts/sitemap-shape.md](./contracts/sitemap-shape.md) — `sitemap.xml` の各エントリの `loc` / `lastmod` / `changeFrequency` / `priority` / `alternates.languages` の決定ルール
+3. **Quickstart / verification**: [quickstart.md](./quickstart.md) — Phase ごとの完了確認コマンド(`curl` / Lighthouse / GSC 操作 / GA4 ビュー設定)を 1 ファイルに集約
+4. **Agent context**: `CLAUDE.md` の `<!-- SPECKIT START --> / <!-- SPECKIT END -->` ブロックに本 plan.md への相対パスを差込
+
+### Post-design Re-check (Constitution)
+
+Phase 1 で確定した URL 設計・データ取得経路は以下の通り Constitution に整合する:
+
+- **I (OpenAPI)**: data-model.md に整理した Company / Industry / Market 取得は既存の generated client(`listSecurityCodes` / `listCompanies` / `listIndustries` / `listMarkets` / `getCompany`)で全て賄える。新規エンドポイント不要 → ✅
+- **II (Runtime Boundaries)**: 全成果物が `typescript/` 配下。Ruby/Go への新規 HTTP・バッチ追加なし → ✅
+- **III (Generated Code Read-Only)**: `typescript/client/**` 不変。生成 SDK の薄いラッパは `typescript/lib/` に新設 → ✅
+- **IV (Gates)**: PR チェックリストとして「`make typescript/lint` 通過」「`npm run build` 通過」「手動確認したページの一覧」を quickstart.md に組み込み → ✅
+- **V (External Services)**: `next/og` の `ImageResponse` は Next.js 標準。Hatenablog / Qiita / Zenn / X / GA4 / GSC は既存。新規 3rd-party 導入なし → ✅
+
+**Post-design gate**: 5/5 Pass、Complexity Tracking エントリなし。
+
+## Complexity Tracking
+
+> なし。Constitution Check で違反は検出されていない。
+
+---
+
+## What `/speckit-plan` produced
+
+- `plan.md` (this file)
+- `research.md`
+- `data-model.md`
+- `quickstart.md`
+- `contracts/url-routes.md`
+- `contracts/sitemap-shape.md`
+- `CLAUDE.md` の SPECKIT ブロック更新
+
+## What `/speckit-plan` did NOT produce (next steps)
+
+- `tasks.md` — `/speckit-tasks` で生成
+- 実装コード — `/speckit-implement` または手動実装

--- a/specs/001-mau-1000-roadmap/quickstart.md
+++ b/specs/001-mau-1000-roadmap/quickstart.md
@@ -1,0 +1,241 @@
+# Quickstart: MAU 1000 達成ロードマップ
+
+**Feature**: 001-mau-1000-roadmap
+**Purpose**: 各 Phase の完了確認手順と、繰り返し実行する検証コマンドをワンストップで提供する。
+
+---
+
+## 前提
+
+```bash
+# リポジトリルートで
+cp .env_sample .env && cp .envrc_sample .envrc
+docker compose build
+make go/install/tools
+cd typescript && npm install && cd -
+```
+
+PR レビュー前のローカルゲート(Constitution IV):
+
+```bash
+make typescript/lint
+docker compose run --rm typescript npm run build
+```
+
+---
+
+## Phase 0(Day 1): GA4 / GSC 整備(オペレーター手作業)
+
+コードを書く前に **必ず**完了させる(これがないと以後の効果測定が成立しない)。
+
+### GA4 設定
+
+1. Admin → Data Streams → Configure tag settings → Define internal traffic
+   - 自宅 / 職場の IPv4 を `internal` ラベルで登録
+2. Admin → Data Settings → Data Filters
+   - "Internal Traffic" を **Active**(Exclude)に切替
+   - "Developer traffic" を **Active**(Exclude)に切替
+3. 探索 → 「実 MAU 計測 Comparison」を作成
+   - 条件: `engagement rate > 0` AND `average session duration > 5s`
+   - **国・地域では除外しない**(VPN 実ユーザーまで除外してしまうため)
+4. Admin → Audiences → "Engaged Users 28d" を作成
+   - 条件: 上記コンディションを 28 日ウィンドウで集計
+
+### GSC 設定
+
+1. ドメインプロパティ `https://www.company-ranking.net/` を登録(URL prefix property ではない)
+2. 所有権確認後、sitemap 提出は Phase 1 完了後
+
+### 完了判定
+
+- GA4 ヘッダで「Comparison: 実 MAU 計測」が選べる
+- GSC で本ドメインプロパティが Verified
+
+---
+
+## Phase 1(Week 1–2): SEO 基盤(コード変更)
+
+### 完了判定コマンド
+
+```bash
+# ローカルビルドが成功し sitemap が生成される
+docker compose run --rm typescript npm run build
+ls typescript/.next/server/app/sitemap.xml typescript/.next/server/app/robots.txt
+
+# 本番デプロイ後
+curl -I https://www.company-ranking.net/sitemap.xml         # 200 OK
+curl -I https://www.company-ranking.net/robots.txt          # 200 OK
+curl -s https://www.company-ranking.net/sitemap.xml | grep -c "<loc>"    # ~7,000
+
+# 主要ページの <head>
+curl -s https://www.company-ranking.net/ja/companies/{ID} | grep -E '(rel="canonical"|hreflang|og:locale)'
+# 期待: canonical=/ja/companies/{ID}、hreflang ja-JP / en-US 各 1、og:locale=ja_JP
+
+# 削除済み企業(存在しない ID)
+curl -I -o /dev/null -s -w "%{http_code}\n" https://www.company-ranking.net/ja/companies/9999999
+# 期待: 404(soft-404 不可)
+```
+
+### GSC 操作
+
+1. Search Console → Sitemaps → `sitemap.xml` を提出
+2. ステータスが「成功」になることを確認(数時間〜数日)
+3. URL Inspection → 主要 20 URL(トップ × 2、companies × 2、主要業界 × 5、主要企業 × 11)を手動インデックス申請
+
+### 完了基準(SC-006)
+
+- [ ] sitemap 提出ステータス「成功」
+- [ ] GSC Indexed URLs ≥ 500
+- [ ] 主要ページの canonical / hreflang / og:locale が正しい
+
+---
+
+## Phase 2(Week 3–4): ページ品質強化
+
+### 完了判定コマンド
+
+```bash
+# JSON-LD が出力されている
+curl -s https://www.company-ranking.net/ja/companies/{ID} | grep -A1 'application/ld+json'
+# 期待: Corporation + BreadcrumbList の 2 ブロック
+
+# Rich Results Test(手動)
+# https://search.google.com/test/rich-results?url=https://www.company-ranking.net/ja/companies/{ID}
+# 期待: Corporation schema 検出
+
+# 並び順 path-tab(FR-012)
+curl -I https://www.company-ranking.net/ja/industries/{ID}/salary    # 200 OK
+curl -s https://www.company-ranking.net/ja/industries/{ID}/salary | grep -E '<title>|canonical'
+# 期待: title に「平均年収」、canonical=self
+
+# 関連企業セクション
+curl -s https://www.company-ranking.net/ja/companies/{ID} | grep -c '/ja/companies/'
+# 期待: 自分 + 関連 10 件以上
+
+# OGP 動的画像
+curl -I https://www.company-ranking.net/ja/companies/{ID}/opengraph-image    # 200 OK image/png
+
+# データ更新日バッジ(FR-014a)
+curl -s https://www.company-ranking.net/ja/companies/{ID} | grep -E 'FY[0-9]{4}|更新日'
+
+# ISR キャッシュ動作
+curl -I https://www.company-ranking.net/ja/companies?sortType=net_sales
+curl -I https://www.company-ranking.net/ja/companies?sortType=net_sales    # 2 回目
+# 期待: x-nextjs-cache: HIT(2 回目)
+```
+
+### GA4 確認
+
+- 平均セッション継続時間 ≥ 25s(SC-002 への中間チェック)
+- ページ/セッション ≥ 1.5
+
+### 完了基準(SC-007)
+
+- [ ] 全主要ページに JSON-LD 出力
+- [ ] Rich Results Test で Corporation schema 検出
+- [ ] 並び順タブ 4 種が path-segment URL で動作
+- [ ] 動的 OGP 画像が返る
+- [ ] 関連企業セクションが企業詳細ページ下部に表示
+- [ ] データ更新日バッジが表示
+- [ ] 実 MAU 200–300
+
+---
+
+## Phase 3(Week 5–8): コンテンツハブ
+
+### 完了判定コマンド
+
+```bash
+# 全ハブ slug が 200 を返す
+for slug in nensyu uriage eigyou-rieki roe; do
+  echo "$slug: $(curl -I -s -o /dev/null -w '%{http_code}' https://www.company-ranking.net/ja/rankings/$slug)"
+done
+
+# Lighthouse(モバイル)
+npx lighthouse https://www.company-ranking.net/ja/rankings/nensyu \
+  --only-categories=seo,performance --form-factor=mobile --output=json | jq '.categories | { seo: .seo.score, perf: .performance.score }'
+# 期待: seo ≥ 0.95, perf ≥ 0.80
+
+# ハブ固有の数値文(FR-016 anti-thin-content)
+curl -s https://www.company-ranking.net/ja/rankings/nensyu | grep -oE '[0-9,]{3,}円' | head -10
+# 期待: 数値固有文が複数(最低 3 個)
+
+# 比較ページ(prebuilt)
+curl -I https://www.company-ranking.net/ja/compare/{idA}/{idB}
+# 期待: 200 OK + 2 社の財務指標
+
+# トップページ強化
+curl -s https://www.company-ranking.net/ja | grep -E 'TOP10|今日の発見|rankings/'
+```
+
+### GSC 確認
+
+- 30+ ハブページが Indexed
+- 5+ ハブが TOP30 内に impressions
+- Hatenablog referral ≥ 50/月(GA4)
+
+### 完了基準(SC-008)
+
+- [ ] 20–30 ランキングハブ稼働、全 200 OK
+- [ ] Lighthouse SEO ≥ 95 / Perf ≥ 80
+- [ ] 上位 200 ペアの比較ページ事前生成
+- [ ] トップページに TOP10 + ファクトイド + ハブティーザー
+- [ ] 実 MAU 400–600
+
+---
+
+## Phase 4(Week 9–12): 最適化 / 複利化
+
+### 完了判定コマンド
+
+```bash
+# Core Web Vitals(SC-009)
+npx lighthouse https://www.company-ranking.net/ja --form-factor=mobile --output=json | \
+  jq '.audits | { lcp: ."largest-contentful-paint".numericValue, cls: ."cumulative-layout-shift".numericValue, inp: ."interaction-to-next-paint".numericValue }'
+# 期待: lcp ≤ 2500ms, cls ≤ 0.1, inp ≤ 200ms
+
+# ハブ拡張
+curl -s https://www.company-ranking.net/sitemap.xml | grep -c '/rankings/'
+# 期待: 80 以上
+
+# 業界 overview
+curl -I https://www.company-ranking.net/ja/industries/{ID}/overview
+
+# sitemap index(URL 数 > 10,000 のとき)
+curl -s https://www.company-ranking.net/sitemap.xml | grep -c sitemapindex
+```
+
+### 完了基準(最終 SC-001 など)
+
+- [ ] **実 MAU(GA4 Engaged Users 28d)≥ 1,000**(本目標)
+- [ ] GSC Indexed ≥ 4,000、TOP10 クエリ ≥ 50
+- [ ] 平均セッション継続時間 ≥ 40s
+- [ ] ページ/セッション ≥ 2.5
+- [ ] Hatenablog referral ≥ 100/月
+- [ ] Top 5 ページの Lighthouse mobile ≥ 80 / SEO ≥ 95
+- [ ] LCP ≤ 2.5s / INP ≤ 200ms / CLS ≤ 0.1
+- [ ] Bot トラフィック割合 < 30%
+
+---
+
+## 共通: PR チェックリスト(Constitution IV)
+
+すべての PR で以下を本文に明記:
+
+- 影響範囲: TypeScript フロントエンドのみ(Go / Ruby / OpenAPI 変更なしを明示)
+- 実行ゲート: `make typescript/lint` 通過 / `npm run build` 通過
+- 手動確認ページ: 該当ページの URL を箇条書き(`/ja/companies/{ID}`、`/ja/industries/{ID}/salary` など)
+- 期待差分: Lighthouse 主要スコアの before/after が劣化していないこと
+
+---
+
+## トラブルシュート
+
+| 症状 | 確認 | 対処 |
+|------|------|------|
+| sitemap が空 | `listSecurityCodes()` 戻り値 | Go API への通信を確認、`NEXT_PUBLIC_API_URL` 確認 |
+| 企業詳細が 200 で空 HTML | RSC が `notFound()` を呼べていない | `getCompany` の Promise 解決を確認、`if (!company) notFound()` を追加 |
+| canonical が `localhost` | `metadataBase` が `process.env` を読んでいない | 本番ビルド時の `NEXT_PUBLIC_SITE_URL` を確認 |
+| OGP 画像が文字化け | フォント未バンドル | `next/font/local` で日本語フォントを同梱 |
+| CLS が悪化 | 関連企業セクションを遅延挿入していないか | SSR 初期 HTML に含める / `min-height` を確保 |
+| GSC で sitemap が「取得できませんでした」 | `robots.txt` で `/sitemap.xml` を Allow しているか | robots ファイルを確認 |

--- a/specs/001-mau-1000-roadmap/research.md
+++ b/specs/001-mau-1000-roadmap/research.md
@@ -1,0 +1,186 @@
+# Phase 0 Research: MAU 1000 達成ロードマップ
+
+**Feature**: 001-mau-1000-roadmap
+**Date**: 2026-05-11
+**Purpose**: spec.md / Technical Context の不明点・技術選定を確定し、Phase 1 設計を進められる状態にする。
+
+---
+
+## R-1. Sitemap 生成方式
+
+**Decision**: Next.js 15 App Router の Metadata Routes 機能(`typescript/app/sitemap.ts`)を採用する。URL 数が **10,000 を超えた段階**で `generateSitemaps` API を使った sitemap index 形式に移行する(FR-026 整合)。
+
+**Rationale**:
+- Next.js 標準。新規ライブラリ不要(Constitution V 整合)
+- ビルド時に静的生成 + `export const revalidate = 86400` で日次更新を実現できる
+- `MetadataRoute.Sitemap` 型で TypeScript チェックが効く
+- `alternates.languages` で hreflang を sitemap 内に埋め込める(FR-001 + FR-004 を 1 ファイルで満たす)
+- 50,000 URL / 50MB の単一 sitemap 上限以内であれば 1 ファイルで足りる。約 25,000 URL(企業 ~3,000 × 2 + 業界 33 × 4 並び順 × 2 + 市場 × 4 × 2 + 静的)は単一で収まる
+
+**Alternatives considered**:
+- 静的 XML を手書き / スクリプトで吐く: ビルドフロー外になり 鮮度・型安全性が落ちる → 不採用
+- `next-sitemap` パッケージ: Next.js 15 と App Router で機能が古い+追加依存。Metadata Routes で足りるため → 不採用
+
+---
+
+## R-2. OGP 画像の動的生成
+
+**Decision**: Next.js の `next/og` パッケージ(`ImageResponse`)を使い、`app/[lang]/companies/[id]/opengraph-image.tsx` 等のファイル規約で 1200×630 PNG を生成する。Edge Runtime 実行。
+
+**Rationale**:
+- Next.js 標準。`@vercel/og` の後継で公式サポート
+- React の TSX 構文で HTML/CSS を書けるため保守性が高い
+- Vercel 上で Edge Function として 自動配信、レスポンスは CDN キャッシュ
+- 外部画像生成 SaaS を導入しない → Constitution V(External Service Boundaries)整合
+
+**Constraints**:
+- フォント: 日本語フォントは ImageResponse にバンドル必要(`fetch` + `unstable_cache`)。Noto Sans JP の subset を `typescript/public/fonts/` に配置する
+- ファイルサイズ: 1 画像あたり ~50–200KB。CDN 経由配信で問題なし
+
+**Alternatives considered**:
+- 静的 PNG(全企業分プリレンダ): 6,000 枚 × 2 ロケール = 12,000 枚。ビルド時間と公開ストレージで非現実的 → 不採用
+- Cloudinary などの画像生成 SaaS: Constitution V の External Service Review が必要、コスト発生 → 不採用
+
+---
+
+## R-3. 構造化データ(JSON-LD)実装
+
+**Decision**: 専用ライブラリは導入せず、各 RSC 内で `<script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(data) }} />` をインライン展開する。共通化のため `typescript/components/JsonLd.tsx` という薄いラッパを新設する。型は `schema-dts` 風の interface を自前で定義(必要分のみ:`Organization`, `WebSite`, `Corporation`, `BreadcrumbList`, `ItemList`, `CollectionPage`)。
+
+**Rationale**:
+- HTML へのインラインで充分、ライブラリ依存を増やさない(Constitution V 精神に整合)
+- RSC のため Server-side で 1 度だけ stringify される。クライアント JS バンドルに影響なし
+- 型は使う 6 スキーマ分のみで足り、`schema-dts` 全体(数百行の型)を入れる必要はない
+
+**Alternatives considered**:
+- `schema-dts` パッケージ: フルセット型が必要十分以上に重く、tree-shaking 後でも開発体験はそれほど向上しない → 不採用
+- `next-seo` パッケージ: 内部で JSON-LD 出力もサポートするが、Next.js 15 の Metadata API と二重管理になる → 不採用
+
+---
+
+## R-4. 並び順タブの URL 設計
+
+**Decision**: `path segment` で実装する。具体的には `/{lang}/industries/{id}/{sortType}` および `/{lang}/markets/{id}/{sortType}`。デフォルト(`net_sales`)のみ `/{lang}/industries/{id}` に正規化(canonical 設定)。
+
+**Rationale**:
+- robots.txt は `Disallow: /*?sortType=*` でクエリ文字列パターンを除外する(FR-002)。同じ仕組みで sortType をクエリ実装すると **インデックスさせたい URL がブロックされる** → 重大バグの予防
+- path segment URL は GSC で個別 URL として認識され、`<title>` 差別化(FR-013)がそのままインデックス時の表示に効く
+- ISR(`revalidate=3600`)が path-key で動作する
+
+**Alternatives considered**:
+- クエリパラメータ(`?sortType=salary`): FR-002 と衝突。robots の Disallow を緩める案もあるが、クロールバジェット浪費(検索クエリ `?q=` を含む)を防ぐ目的が崩れる → 不採用
+- 値ごとに独立ルート(`/industries/{id}-salary`): 動的ルート爆発、保守性低下 → 不採用
+
+**sortType の語彙**(全ロケール共通の URL 用 slug):
+
+| slug | 並び順 | カラム |
+|------|--------|--------|
+| (なし) | デフォルト(売上) | `net_sales` desc |
+| `salary` | 平均年収 | `average_annual_salary` desc |
+| `op-income` | 営業利益 | `operating_income` desc |
+| `equity` | 自己資本比率 | `equity_to_asset_ratio` desc |
+
+`<title>` での日本語表示は `dictionaries/{lang}.json` の `sortType.{slug}` から引く。
+
+---
+
+## R-5. 比較ページ(`/{lang}/compare/{idA}/{idB}`)の事前生成範囲
+
+**Decision**: `generateStaticParams` で「同業界・売上規模が近い上位 200 ペア」を事前生成する。それ以外は `dynamicParams: true` + `export const revalidate = 86400` で on-demand ISR にする。
+
+**Rationale**:
+- 全 3,000 社の組み合わせは C(3000, 2) ≈ 4.5M ペア。Vercel ビルドタイムアウト・成果物サイズ的に非現実的
+- 上位 200 ペアは「同業界トップ 10 × ペア(45) × 主要 5 業界 ≒ 225 → 200 に丸め」。検索流入も「{A社} {B社} 比較」系で需要が見込めるトップから優先
+- on-demand ISR は初回アクセス時にだけ生成、2 回目以降はキャッシュヒット。低頻度ペアでもインデックス対象に含められる
+
+**Alternatives considered**:
+- 全ペア事前生成: ビルド時間爆発、Vercel 月間ビルド時間予算超過 → 不採用
+- すべて on-demand ISR(`generateStaticParams` 空): TTFB が悪化、初回ユーザー体験が低下 → 不採用
+
+---
+
+## R-6. データ更新日 / 会計年度の取得元
+
+**Decision**: 既存の `getCompany`/ documents 関連レスポンスに含まれる **対象会計年度 (fiscal year)** と **最終 document 提出日** を再利用。新規 API 追加は不要。フィールドが命名揺れで取りづらい場合は `typescript/lib/seo.ts` 内に小さな normalizer を用意する。
+
+**Rationale**:
+- 既存 API のみで賄えるなら Constitution I(OpenAPI Contract)も触れずに済む
+- 表示位置は H1 直下 / サイドバーで、レイアウト崩れがないことを Lighthouse CLS で担保(SC-009 整合)
+
+**Alternatives considered**:
+- 新規 API `/companies/{id}/freshness` を追加: OpenAPI 変更 + 全プロセス再生成が必要。コスト過大 → 不採用
+- 静的に固定文言(「最新の有価証券報告書ベース」)のみ表示: ユーザーへの情報量不足、edge case 7 のリスク残存 → 不採用
+
+---
+
+## R-7. 404 / soft-404 対策
+
+**Decision**: 動的ルートのデータ取得後に対象が存在しなければ Next.js の `notFound()` を呼び、`app/not-found.tsx`(必要なら locale 配下にも追加)で 404 HTML を返す。同時に `sitemap.ts` が出力時に「現存する企業 ID のみ」を列挙することで、消えた URL が sitemap に残らないようにする。
+
+**Rationale**:
+- `notFound()` は HTTP 404 を返す Next.js 標準の仕組み。soft-404(200 OK + 空) を確実に避けられる
+- sitemap は日次再生成(`revalidate=86400`)なので、企業 ID が消えた翌日には URL も消える
+- Google の de-indexing は 404 検出から数週間で完了するため、放置するより早く除外させたほうが「全体のインデックス品質」が上がる
+
+---
+
+## R-8. ハブページのコメンタリ生成戦略
+
+**Decision**: スラッグごとに「テンプレ + データ駆動文」のハイブリッド。テンプレ文は H2 セクションと枠組み(導入・上位企業ハイライト・業界全体傾向・FAQ)を提供し、データ駆動文(FR-016 で要求される 3 文以上)は `typescript/lib/factoids.ts` の関数で次のような文を自動生成:
+
+- 1 位企業の値と社名
+- 上位 5 社の合計値・平均
+- 同指標の業界別 TOP3
+- 前年比成長(`lastYearNetSales` 差分から算出)
+- 中央値 / TOP / BOTTOM の比率
+
+**Rationale**:
+- 完全テンプレ流用は doorway page 認定リスク(edge case 2 / risk 1)
+- LLM 生成テキストは品質ブレ・コスト・External Service Review が必要 → Constitution V との衝突
+- データ駆動の数値文は自動で 一意 になり、スラッグごとに毎回違う表現になる
+
+---
+
+## R-9. Lighthouse / Core Web Vitals 維持戦略
+
+**Decision**: 以下を実装段階の non-functional checklist として固定:
+
+- **画像**: OGP 画像は `priority` 不要(below the fold)。LCP に効くファビコン的サムネは未導入
+- **フォント**: Noto Sans JP の subset(JIS 第 1 水準)を `next/font/local` で自家ホスト、`display: swap`
+- **JS バンドル**: Server Components を主用、Client Components(`'use client'`)はシェアボタンなどインタラクションが必須な箇所のみ
+- **CSS**: 既存の `styles/globals.css` を維持、Tailwind 等の追加は不要
+- **CLS**: データ更新日バッジ・関連企業セクション・並び順タブは すべて初期 HTML に含めて遅延挿入しない
+- **INP**: 並び順切替は `<Link>`(prefetch あり)で動かし、クライアント側状態管理は導入しない
+
+**Rationale**: SC-009 の Core Web Vitals 閾値(LCP ≤ 2.5s / INP ≤ 200ms / CLS ≤ 0.1)は Google ランキングに直接効く。SEO 施策で本末転倒にしないため、設計段階で破壊しない選択を固定する。
+
+---
+
+## R-10. 国際化(日本語 / 英語)スコープ
+
+**Decision**: 英語ページは技術 SEO(sitemap / hreflang / canonical / og:locale / JSON-LD)のみ整備し、コンテンツ拡張(ランキングハブ / 比較ページ / 業界 overview / 関連企業)は **日本語のみ**を対象とする。ただしルート構造は両ロケール対応で実装し、英語版で追加コンテンツが必要になったときに辞書追加で展開できる形にする。
+
+**Rationale**:
+- spec.md の Assumptions に明記された方針(MAU 1000 の内訳は日本語 ~950 / 英語 ~50)
+- 1 人 × 15h/週の運用工数で英語コンテンツまでカバーすると Hatenablog 執筆と両立不能
+- ルート構造を 2 ロケール対応にしておけば後から英訳辞書を足すだけで展開可能
+
+**Alternatives considered**:
+- 英語ハブも初期から作成: 工数超過、品質低下 → 不採用
+- 英語版を完全 deprecate(`/en` を 410 化): SEO 上はクリーンだが ユーザー目標として English UI 自体は維持したい → 不採用
+
+---
+
+## R-11. GA4 / GSC 設定変更の責務分担
+
+**Decision**: GA4 の内部トラフィック除外 / 実 MAU 計測ビュー / Engaged Users 28d オーディエンス、および GSC のドメインプロパティ登録 / sitemap 提出は **オペレーター手作業**として扱い、コード変更には含めない。実施手順は `quickstart.md` の Phase 0 / Phase 1 セクションに完全な操作手順として記録する。
+
+**Rationale**:
+- GA4 / GSC の設定は UI 操作で行うのが現実的(API 化は工数に見合わない)
+- オペレーター責務として明示することで、PR レビュアーが「これはコード差分では満たされない」と判別しやすい
+
+---
+
+## All NEEDS CLARIFICATION resolved
+
+spec.md / Technical Context に残っていた不明点は本ドキュメントで全て確定した。Phase 1 設計に進む準備が整っている。

--- a/specs/001-mau-1000-roadmap/spec.md
+++ b/specs/001-mau-1000-roadmap/spec.md
@@ -81,6 +81,10 @@
 - **モバイル性能不足**: モバイル Lighthouse スコアが 80 未満のページがあると Google の Core Web Vitals 評価で不利になる。Top 5 ページは定期計測する。
 - **GSC インデックスサンプリング上限**: 一般的に ~1000 URL のサンプリングしか反映されないため、優先発見させたい URL は内部リンクで強調する。
 - **VPN ユーザーの誤排除**: 地域単位での bot 除外を行うと VPN 経由の実ユーザーまで除外される。地域ベースではなく engagement ベースでフィルタする。
+- **クエリ文字列によるクロール阻害**: `?sortType=*` を robots.txt で Disallow にすると、並び順切替を query param で実装した場合に該当 URL がクロールされない。並び順は path segment(例: `/industries/{id}/salary`)で実装する必要がある。
+- **クッキー同意 / プライバシー規制**: 訪問数が増えると、特に EU・日本の改正電気通信事業法対応で GA4 のクッキー同意 UI が必要になる可能性。導入時はバナー表示が CLS / Core Web Vitals に悪影響しないよう設計する。
+- **削除・上場廃止された企業 URL**: EDINET データ更新で消えた企業ページを 200 OK + 空コンテンツ(soft-404)で返すと、Google にスパム的なテンプレと判定される。**HTTP 404** を返してインデックスから除去させる。
+- **コンテンツの薄さ判定**: テンプレで生成しただけのハブページは Google から「中身のないテンプレ」と判定され順位がつかない。データから抽出した固有の数値文を最低 3 文以上は含める。
 
 ## Requirements *(mandatory)*
 
@@ -95,6 +99,8 @@
 - **FR-005**: System MUST sitemap を Google Search Console に提出し、提出ステータスが「成功」になる
 - **FR-006**: System MUST 実 MAU を計測するための GA4 ビュー(engagement rate > 0 かつ avg session duration > 5s)を提供する
 - **FR-007**: System MUST GA4 で内部トラフィック・開発者トラフィックを除外する設定を有効化する
+- **FR-007a**: System MUST SEO 対象ページ(企業詳細・企業リスト・業界・市場・ランキングハブ・トップ)の初期 HTML レスポンス内に主要コンテンツ(タイトル・主要数値・ランキングテーブル)を含めて返す(SSR / SSG / ISR を使用し、JavaScript 実行を前提とするレンダリングは行わない)
+- **FR-007b**: System MUST EDINET データ更新により参照先が消えた企業 URL に対し、HTTP 404 ステータスを返す(空コンテンツの 200 OK = soft-404 は禁止)。sitemap からも該当 URL を除外する
 
 #### ページ品質と内部リンク (Phase 2)
 
@@ -102,14 +108,15 @@
 - **FR-009**: System MUST 企業リスト・業界詳細・市場詳細ページを ISR(1 時間間隔の再生成)でキャッシュ配信する
 - **FR-010**: System MUST 企業詳細・業界詳細・市場詳細の OGP 用画像を動的生成し、企業名・主要指標・業界タグなどを 1200×630 で含める
 - **FR-011**: System MUST 企業詳細ページの下部に「同業界の売上 TOP5」「同市場の売上 TOP5」の関連企業リンクセクションを表示する
-- **FR-012**: System MUST 業界・市場ページに並び順タブ(売上 / 平均年収 / 営業利益 / 自己資本比率)を提供し、それぞれを別 URL として sitemap に含める
+- **FR-012**: System MUST 業界・市場ページに並び順タブ(売上 / 平均年収 / 営業利益 / 自己資本比率)を提供し、それぞれを **path segment** ベースの別 URL として sitemap に含める(例: `/{lang}/industries/{id}/salary`)。クエリパラメータ実装は FR-002 の robots Disallow と衝突するため禁止
 - **FR-013**: System MUST 並び順タブ URL の `<title>` に並び順を含めて差別化する(例: 「{業界名} 平均年収ランキング」)
 - **FR-014**: System MUST 企業詳細ページに X / はてなブックマークへのシェアボタンを設置する
+- **FR-014a**: System MUST 企業詳細・業界詳細・市場詳細ページに「対象会計年度 (FY)」と「データ更新日」を視認できる位置(H1 直下またはサイドバー)に表示する
 
 #### コンテンツハブ (Phase 3)
 
 - **FR-015**: System MUST ランキングハブルート `/{lang}/rankings/{slug}` を提供し、初期 20-30 スラッグ(年収 / 売上 / 営業利益 / ROE および 業界横断クロス)をサポートする
-- **FR-016**: Each ranking hub page MUST 800 文字以上のユニークなコメンタリ(データ駆動で自動生成可)・H2 セクション・ランキングテーブル・パンくず・JSON-LD `ItemList`・詳細ページへの 5 件以上のリンクを含む
+- **FR-016**: Each ranking hub page MUST 800 文字以上のユニークなコメンタリ・H2 セクション・ランキングテーブル・パンくず・JSON-LD `ItemList`・詳細ページへの 5 件以上のリンクを含む。コメンタリには **当該スラッグ固有の数値を引用した文を 3 文以上**含めること(例: 「1 位は{社名}の{値}円」「平均は{値}円」「上位 5 社の合計シェアは {%}」)。テンプレ流用のみで数値固有文が 3 文未満の場合は publish 不可
 - **FR-017**: System MUST 2 社の財務指標を比較する `/{lang}/compare/{idA}/{idB}` ページを提供する。上位 200 ペアを事前生成し、それ以外は on-demand ISR で配信する
 - **FR-018**: System MUST トップページのファーストビューに「売上 TOP10 ミニテーブル」「今日の発見ファクトイド」「ランキングハブ 3 件のティーザー」を含める
 - **FR-019**: System MUST 全ランキングハブ URL を sitemap に含める
@@ -149,7 +156,7 @@
 - **SC-006**: Phase 1 完了(2 週時点)で sitemap 提出ステータスが「成功」、500 以上の URL が Indexed されている
 - **SC-007**: Phase 2 完了(4 週時点)で実 MAU が **200-300**、企業詳細ページの Google Rich Results Test で `Corporation` スキーマが検出される
 - **SC-008**: Phase 3 完了(8 週時点)で 30+ ハブページが Indexed、5+ ハブが GSC TOP30 内に impression を獲得、累計実 MAU が **400-600**
-- **SC-009**: 全主要ページの Lighthouse SEO スコアが **95 以上**、モバイル Performance スコアが **80 以上**
+- **SC-009**: 全主要ページの Lighthouse SEO スコアが **95 以上**、モバイル Performance スコアが **80 以上**。Core Web Vitals が以下を満たす:**LCP ≤ 2.5s**、**INP ≤ 200ms**、**CLS ≤ 0.1**(Google ランキング直接要因)
 - **SC-010**: Bot トラフィック(engagement rate 0% / avg session duration 0s)の割合が全セッションの **30% 未満**に維持される
 
 ## Assumptions

--- a/specs/001-mau-1000-roadmap/spec.md
+++ b/specs/001-mau-1000-roadmap/spec.md
@@ -1,0 +1,166 @@
+# Feature Specification: MAU 1000 達成ロードマップ
+
+**Feature Branch**: `001-mau-1000-roadmap`
+**Created**: 2026-05-11
+**Status**: Draft
+**Input**: User description: "@docs/mau-1000-roadmap.md に記載があるが、MAU1000を目指している。"
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - 検索エンジン経由でランキングページに到達する (Priority: P1)
+
+日本の求職者・投資家・就活生が Google で「企業 年収 ランキング」「{業界名} 売上 ランキング」などのクエリを検索した際、company-ranking.net の該当ページが検索結果に表示され、クリックして欲しい情報(企業ランキング・財務指標・年収比較)に最短で到達できる。
+
+**Why this priority**: 唯一実績のある成長チャネルが Organic Search であり、サイトには SEO 基盤(sitemap / robots / 構造化データ / hreflang)が一切ないため、ここを整備することが MAU 拡大の最大レバーである。SEO 基盤がなければ後続施策(ハブページ・コンテンツ拡充)の効果も発揮されない。
+
+**Independent Test**: Google Search Console で sitemap が「成功」ステータスとして登録され、主要 URL が Indexed 状態で、クエリ「{企業名} 年収」「{業界} ランキング」で 30 位以内に表示されることを確認することでテスト可能。これだけで実質ユーザー約 100 → 200-300 への成長が見込める。
+
+**Acceptance Scenarios**:
+
+1. **Given** ユーザーが Google で「日本企業 平均年収 ランキング」と検索する, **When** 検索結果ページを表示する, **Then** company-ranking.net の年収ランキングページが結果に含まれる
+2. **Given** ユーザーが企業詳細ページを SNS にシェアする, **When** リンクが展開される, **Then** 企業名・売上・業界が表示された OGP カードが表示される
+3. **Given** クローラーが sitemap.xml にアクセスする, **When** XML を取得する, **Then** ~6,000 件の企業・業界・市場 URL が言語別に列挙され、各エントリに hreflang が付与されている
+4. **Given** 日本語ページが Google にインデックスされる, **When** 検索結果に表示される, **Then** og:locale が `ja_JP` として認識され、英語ページとは別 URL として扱われる
+
+---
+
+### User Story 2 - ランキングページから関連ページを回遊する (Priority: P2)
+
+ユーザーが企業詳細ページに到達した後、同業界の競合企業や同市場の他社、年収比較ページなどに自然に遷移し、複数のページを閲覧することでサイト全体の価値を体験できる。
+
+**Why this priority**: P1 で集客した訪問者をすぐに離脱させない仕組みが MAU 維持に必要。現状の平均セッション継続時間 13 秒は短すぎ、Google にも「ユーザーが満足していないサイト」と認識される。内部リンクと構造化データはクロール深度・滞在時間を同時に改善する。
+
+**Independent Test**: 企業詳細ページから「関連企業」セクションへのクリック率、平均セッション継続時間が 25 秒以上、ページ/セッションが 2.0 以上になることを GA4 で確認することでテスト可能。
+
+**Acceptance Scenarios**:
+
+1. **Given** ユーザーが企業 A の詳細ページを開く, **When** ページ下部までスクロールする, **Then** 同業界 TOP5 と同市場 TOP5 の企業リンクが表示される
+2. **Given** ユーザーが業界ページを開く, **When** 並び順タブをクリックする, **Then** 売上・平均年収・営業利益・自己資本比率の 4 種類で再ソートされた URL に遷移する
+3. **Given** Google Rich Results Test で企業詳細 URL を検証する, **When** 結果が返る, **Then** `Corporation` schema と `BreadcrumbList` が検出される
+4. **Given** ユーザーが企業詳細ページの X シェアボタンを押す, **When** Twitter intent が開く, **Then** 企業名・カノニカル URL を含むツイート下書きが生成される
+
+---
+
+### User Story 3 - 検索意図特化のハブページに直接ランディングする (Priority: P3)
+
+「年収ランキング」「ROE ランキング」「{業界} 平均年収」など、ロングテールの検索意図に対応する専用ハブページが存在し、ユーザーがそこで欲しい情報のサマリ・解説・上位企業リンクを一気に得られる。
+
+**Why this priority**: 個別企業ページだけでは取りきれない「ランキング系」「比較系」クエリを獲得するには専用のハブが必要。インデックス反映に 4-6 週かかるため、P1/P2 の後で投入してフェーズ後半の成長を担う。
+
+**Independent Test**: 30+ ハブページが Google Search Console で Indexed となり、5+ ハブが TOP30 内に impressions を獲得することを確認することでテスト可能。
+
+**Acceptance Scenarios**:
+
+1. **Given** ユーザーが `/ja/rankings/nensyu` に直接アクセスする, **When** ページを表示する, **Then** 平均年収 TOP の上位企業リスト・固有のコメンタリ(800 字以上)・パンくず・関連リンクが表示される
+2. **Given** ユーザーが 2 社比較ページにアクセスする, **When** `/ja/compare/{idA}/{idB}` を開く, **Then** 両社の財務指標が横並びで表示される
+3. **Given** ハブページを Lighthouse で計測する, **When** SEO カテゴリのスコアを取得する, **Then** スコアが 95 以上
+
+---
+
+### User Story 4 - 外部メディアからの被リンク・流入を獲得する (Priority: P3)
+
+技術ブログ(Hatenablog / Qiita / Zenn)や X からの参照リンク・OGP 共有を通じて、検索以外のチャネルから新規ユーザーがサイトに流入する。
+
+**Why this priority**: Organic Search 単独では成長スピードに上限があるため、複利的に効く被リンク・SNS 経由流入を並行して育てる必要がある。ただしコンテンツ生産にコストがかかるため P3。
+
+**Independent Test**: GA4 Referral レポートで Hatenablog ドメインからの月間訪問が 50+ であること、被リンクを獲得した URL が GSC の被リンクレポートに反映されていることを確認することでテスト可能。
+
+**Acceptance Scenarios**:
+
+1. **Given** Hatenablog 記事内のリンクをユーザーがクリックする, **When** company-ranking.net に着地する, **Then** GA4 で `hatenablog.jp` が Referral source として記録される
+2. **Given** X で企業詳細 URL を投稿する, **When** タイムラインに表示される, **Then** 動的生成された OGP カード(企業名・証券コード・売上・業界)が展開表示される
+
+---
+
+### Edge Cases
+
+- **Bot トラフィック流入**: GA4 で Singapore / China などの engagement rate 0% トラフィックが再度急増した場合、MAU 数値が水増しされて実態が見えなくなる。対策として実 MAU 計測ビュー(engagement rate > 0 かつ avg session duration > 5s)を北極星指標として使用する。
+- **doorway page 認定リスク**: 自動生成のハブページが Google から「中身のないテンプレページ」と判定されると検索順位が付かない。各ハブには 800 字以上の固有コメンタリ・データ表・内外部リンクを必ず配置する。
+- **インデックス未反映**: sitemap 提出後も Google が URL を発見しないケース。トップから業界・市場・ハブへの内部リンクを必ず張り、主要 20 URL は手動インデックス申請を行う。
+- **データ鮮度の誤認**: EDINET 由来のデータは過去会計年度のため、ユーザーが「最新ではない」と離脱する可能性。各ページに「データ更新日」と「対象会計年度」を明示する。
+- **モバイル性能不足**: モバイル Lighthouse スコアが 80 未満のページがあると Google の Core Web Vitals 評価で不利になる。Top 5 ページは定期計測する。
+- **GSC インデックスサンプリング上限**: 一般的に ~1000 URL のサンプリングしか反映されないため、優先発見させたい URL は内部リンクで強調する。
+- **VPN ユーザーの誤排除**: 地域単位での bot 除外を行うと VPN 経由の実ユーザーまで除外される。地域ベースではなく engagement ベースでフィルタする。
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+#### SEO 基盤 (Phase 1)
+
+- **FR-001**: System MUST 全公開ページの URL を網羅した sitemap を自動生成して `/sitemap.xml` で公開する(静的ページ + 全企業 + 全業界 + 全市場、両ロケール分)
+- **FR-002**: System MUST `/robots.txt` を公開し、クロール対象を許可しつつクエリ文字列パターン(`?q=*`, `?sortType=*`)はクロール対象から除外する
+- **FR-003**: System MUST 各 URL の `<head>` に正しい言語の `og:locale`(日本語 → `ja_JP`、英語 → `en_US`)を出力する
+- **FR-004**: System MUST 各ページの `<head>` に canonical URL と、対応する別言語ページへの `hreflang` リンクを出力する(対象: 企業詳細・企業リスト・業界詳細・市場詳細)
+- **FR-005**: System MUST sitemap を Google Search Console に提出し、提出ステータスが「成功」になる
+- **FR-006**: System MUST 実 MAU を計測するための GA4 ビュー(engagement rate > 0 かつ avg session duration > 5s)を提供する
+- **FR-007**: System MUST GA4 で内部トラフィック・開発者トラフィックを除外する設定を有効化する
+
+#### ページ品質と内部リンク (Phase 2)
+
+- **FR-008**: System MUST 全ページの `<head>` 内に JSON-LD 構造化データを出力する(レイアウト: `Organization` + `WebSite`、企業詳細: `Corporation` + `BreadcrumbList`、業界・市場: `ItemList` + `BreadcrumbList` + `CollectionPage`)
+- **FR-009**: System MUST 企業リスト・業界詳細・市場詳細ページを ISR(1 時間間隔の再生成)でキャッシュ配信する
+- **FR-010**: System MUST 企業詳細・業界詳細・市場詳細の OGP 用画像を動的生成し、企業名・主要指標・業界タグなどを 1200×630 で含める
+- **FR-011**: System MUST 企業詳細ページの下部に「同業界の売上 TOP5」「同市場の売上 TOP5」の関連企業リンクセクションを表示する
+- **FR-012**: System MUST 業界・市場ページに並び順タブ(売上 / 平均年収 / 営業利益 / 自己資本比率)を提供し、それぞれを別 URL として sitemap に含める
+- **FR-013**: System MUST 並び順タブ URL の `<title>` に並び順を含めて差別化する(例: 「{業界名} 平均年収ランキング」)
+- **FR-014**: System MUST 企業詳細ページに X / はてなブックマークへのシェアボタンを設置する
+
+#### コンテンツハブ (Phase 3)
+
+- **FR-015**: System MUST ランキングハブルート `/{lang}/rankings/{slug}` を提供し、初期 20-30 スラッグ(年収 / 売上 / 営業利益 / ROE および 業界横断クロス)をサポートする
+- **FR-016**: Each ranking hub page MUST 800 文字以上のユニークなコメンタリ(データ駆動で自動生成可)・H2 セクション・ランキングテーブル・パンくず・JSON-LD `ItemList`・詳細ページへの 5 件以上のリンクを含む
+- **FR-017**: System MUST 2 社の財務指標を比較する `/{lang}/compare/{idA}/{idB}` ページを提供する。上位 200 ペアを事前生成し、それ以外は on-demand ISR で配信する
+- **FR-018**: System MUST トップページのファーストビューに「売上 TOP10 ミニテーブル」「今日の発見ファクトイド」「ランキングハブ 3 件のティーザー」を含める
+- **FR-019**: System MUST 全ランキングハブ URL を sitemap に含める
+
+#### 外部発信 (Phase 3-4 並行)
+
+- **FR-020**: Operator MUST Hatenablog で週 2 本ペースの長文記事を継続的に投稿し、ランキングページへの被リンクを獲得する
+- **FR-021**: Operator MUST Qiita または Zenn に技術記事を 1 本以上投稿し、本サイトへの被リンクを獲得する
+- **FR-022**: Operator MUST X で週 2-3 投稿の頻度で OGP カードを活用した発信を継続する
+
+#### 複利化と最適化 (Phase 4)
+
+- **FR-023**: Operator MUST GSC の「impressions あり / CTR 低」クエリを週次で抽出し、該当ページの `<title>` / `description` を最適化する(2026 などの年号・「3000 社中」などの規模表記・「最新版」フックを含める)
+- **FR-024**: System MUST ランキングハブを 80-100 スラッグまで拡張する(業界別年収 / 利益率 / YoY 成長率)
+- **FR-025**: System MUST 業界深掘りページ `/{lang}/industries/{id}/overview` を提供し、1500 文字以上のコメンタリ + 主要プレイヤー + 埋込ミニランキングを含める
+- **FR-026**: System MUST URL 数が 10,000 を超えた場合、sitemap を `sitemap-companies.xml` / `sitemap-rankings.xml` 等に分割した sitemap index 形式に切り替える
+- **FR-027**: Top 5 ページの Lighthouse モバイルスコアが 80 を超えていなければならない
+
+### Key Entities *(include if feature involves data)*
+
+- **企業 (Company)**: 約 3,000 上場企業。証券コード・名称・業界 ID・市場 ID・所在地・従業員数・売上 (`netSales`)・前期売上 (`lastYearNetSales`)・営業利益 (`operatingIncome`)・平均年収 (`averageAnnualSalary`)・自己資本比率 (`equityToAssetRatio`)・ROE などを持つ。企業詳細ページ・OGP 画像・関連企業セクションのデータ源。
+- **業界 (Industry)**: 33 業界。企業を分類し、ランキング・並び順タブ・ハブページの軸となる。両ロケールで名称を持つ。
+- **市場 (Market)**: 上場市場分類。企業の所属市場で、ランキング・関連企業セクションの軸の 1 つ。
+- **ランキングハブ (Ranking Hub)**: スラッグ・並び順指標・任意の業界/市場フィルタ・ロケール別 H1・導入文を持つ静的に定義された URL 単位。初期 20-30 件→拡張 80-100 件。
+- **GA4 イベント / ビュー**: 実 MAU 計測ビュー(`Engagement rate > 0` ∧ `Avg session duration > 5s`)、「Engaged Users 28d」オーディエンスが北極星指標として機能する。
+- **Search Console プロパティ**: ドメインプロパティ `https://www.company-ranking.net/`。sitemap 提出・インデックス状態・クエリパフォーマンスの観測点。
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: 実 MAU(GA4「Engaged Users 28d」、engagement rate > 0 かつ avg session duration > 5s フィルタ適用)が 12 週間以内に **1,000 を超える**
+- **SC-002**: 平均セッション継続時間が 12 週間以内に **40 秒以上**(現状 13 秒)になる
+- **SC-003**: 1 セッションあたりのページビュー数が 12 週間以内に **2.5 以上**になる
+- **SC-004**: 12 週間以内に Google Search Console 上で **4,000 以上の URL が Indexed** となり、50 件以上のクエリで TOP10 順位を獲得する
+- **SC-005**: Hatenablog 経由の月間 Referral 訪問が 12 週間以内に **100 以上**になる
+- **SC-006**: Phase 1 完了(2 週時点)で sitemap 提出ステータスが「成功」、500 以上の URL が Indexed されている
+- **SC-007**: Phase 2 完了(4 週時点)で実 MAU が **200-300**、企業詳細ページの Google Rich Results Test で `Corporation` スキーマが検出される
+- **SC-008**: Phase 3 完了(8 週時点)で 30+ ハブページが Indexed、5+ ハブが GSC TOP30 内に impression を獲得、累計実 MAU が **400-600**
+- **SC-009**: 全主要ページの Lighthouse SEO スコアが **95 以上**、モバイル Performance スコアが **80 以上**
+- **SC-010**: Bot トラフィック(engagement rate 0% / avg session duration 0s)の割合が全セッションの **30% 未満**に維持される
+
+## Assumptions
+
+- 計測対象は GA4 の「実 MAU 計測ビュー」(engagement rate > 0 かつ avg session duration > 5s)で算出する値であり、GA4 デフォルトの 28 日アクティブユーザー数ではない。1000 という目標値は実ユーザー基準。
+- 主要ターゲットは日本語ユーザー。英語ページは技術的な SEO 基盤(sitemap / hreflang / canonical)のみ整備し、コンテンツ拡張やハブ展開は対象外。MAU 1000 の内訳は日本語 ~950 / 英語 ~50 を想定。
+- 有料広告(Google Ads / Meta Ads など)は使用しない。集客は Organic Search + Referral + Direct + SNS のオーガニックチャネルに限定する。
+- 運用工数の目安は **1 人 × 約 15 時間 / 週**。不足時の削減優先順位は (i) 比較ページ → (ii) EN 改善 → (iii) OGP 動的画像。
+- データ源は既存の Postgres(EDINET スクレイピング・JPX スクレイピング由来)を継続利用。新規データ取得・新規外部 API 連携は本計画には含まれない。
+- 既存の Next.js 15 App Router / Go API / Ruby バッチ構成は変更しない(`go/**/*.gen.go`, `go/models/*.xo.go`, `typescript/client/**` は生成物のため触らない)。
+- 構造化データ・OGP 画像の生成は Next.js 標準機能(Metadata API / `next/og` の `ImageResponse`)で完結する。
+- ハブページのコメンタリは既存データからのテンプレート生成で 800 字以上を確保できる(主観評論ではなく数値ベースの記述)。
+- Bot 除外の対応は GA4 内のフィルタおよびレポート定義で行う。サーバ側で IP ブロック・UA ブロックを行うのは Singapore / China Direct が再び全セッションの 50% を超えた場合のみ。
+- GSC ドメインプロパティの管理権限はオペレーターが所有しており、sitemap 提出・インデックス申請・データ取得が可能。

--- a/specs/001-mau-1000-roadmap/tasks.md
+++ b/specs/001-mau-1000-roadmap/tasks.md
@@ -1,0 +1,321 @@
+---
+description: "Task list for MAU 1000 達成ロードマップ (001-mau-1000-roadmap)"
+---
+
+# Tasks: MAU 1000 達成ロードマップ
+
+**Input**: Design documents in `/specs/001-mau-1000-roadmap/`
+**Prerequisites**: plan.md, spec.md, research.md, data-model.md, contracts/url-routes.md, contracts/sitemap-shape.md, quickstart.md
+**Tests**: TypeScript には自動ユニットテストなし(Constitution IV / plan.md)。各タスクの検証は `make typescript/lint` + `docker compose run --rm typescript npm run build` + quickstart.md に列挙された手動ブラウザ確認で行う。
+
+## PR 運用ルール
+
+- **タスク = 1 PR** を原則とする。各タスクは独立したブランチで実装し、PR 本文に以下を必ず明記する:
+  - 該当 Task ID(例: `T005`)
+  - 影響範囲(TypeScript フロントエンドのみであることを明示)
+  - 手動確認した URL のリスト(quickstart.md の検証コマンドを引用可)
+  - `make typescript/lint` 通過 / `npm run build` 通過のチェック
+- **`[P]` マークの意味**: 触るファイルが他タスクと重ならず、依存する先行タスクがすべてマージ済みであれば、並行して別ブランチで開発・PR を開いてよい。
+- **依存タスクが未マージ**の場合、その PR は依存先がマージされるまでドラフトのままにしておく。
+- **生成コード**(`typescript/client/**`)は本ロードマップ全体で**編集禁止**(Constitution III)。
+- **Go / Ruby / OpenAPI 変更なし**(plan.md / Constitution II)を全 PR で守る。
+
+## Format: `- [ ] [ID] [P?] [Story?] Description (file path)`
+
+---
+
+## Phase 0: Operator-only Setup (No PR)
+
+> コードを書く前に **必ず**完了させる(plan.md / quickstart.md Phase 0)。PR は発生しない運用作業として扱う。
+
+- [ ] OPS-001 GA4: 内部 / Developer Traffic 除外フィルタを Active にする(Admin → Data Settings → Data Filters)
+- [ ] OPS-002 GA4: "実 MAU 計測 Comparison"(`engagement rate > 0` ∧ `avg session duration > 5s`)を作成
+- [ ] OPS-003 GA4: "Engaged Users 28d" オーディエンスを作成
+- [ ] OPS-004 GSC: ドメインプロパティ `https://www.company-ranking.net/` を登録 + 所有権確認
+
+**Checkpoint**: GA4 で実 MAU Comparison が選べ、GSC ドメインプロパティが Verified。これがないと SC-001 / SC-006 の計測ができない。
+
+---
+
+## Phase 1: Setup (Shared Infrastructure)
+
+**Purpose**: 後続フェーズが共通して依存する環境変数 / 基底 metadata の整備
+
+- [ ] T001 `.env_sample` と `compose.yaml` に `NEXT_PUBLIC_SITE_URL=https://www.company-ranking.net` を追加し、`typescript/app/[lang]/layout.tsx` の `metadataBase` を `new URL(process.env.NEXT_PUBLIC_SITE_URL ?? "http://localhost:3000")` で参照するよう変更する(canonical 計算の基底値が正しく解決される状態にする)
+
+**Checkpoint**: ローカルビルドで `<link rel="canonical">` のホストが localhost、本番ビルドで `www.company-ranking.net` に解決されることを確認できる。
+
+---
+
+## Phase 2: Foundational (Blocking Prerequisites)
+
+**Purpose**: 全 User Story が依存する共通ヘルパ / 型 / UI プリミティブ。Phase 2 の全タスクが完了するまで Phase 3 以降のタスクは開始できない(`[P]` 同士は並行可)。
+
+- [ ] T002 [P] `typescript/lib/seo.ts` を新規作成し、`canonicalFor(path, lang)` / `hreflangAlternates(path)` / `ogLocaleFor(lang)` を実装する(contracts/url-routes.md §4–6 のルールに準拠)
+- [ ] T003 [P] `typescript/components/JsonLd.tsx` を新規作成し、`<script type="application/ld+json">` の薄いラッパと `Organization` / `WebSite` / `Corporation` / `BreadcrumbList` / `ItemList` / `CollectionPage` の自前 interface を定義する(research.md R-3)
+- [ ] T004 [P] `typescript/lib/og-image.tsx` を新規作成し、`ImageResponse` 用の共通レイアウト(1200×630)と Noto Sans JP のフォントローダ(`typescript/public/fonts/` に配置)を実装する。本タスクではローダのみで、各エンドポイントは Phase 4 で実装(research.md R-2)
+
+**Checkpoint**: 3 つの共通モジュールが `npm run build` を通過し、import エラーが出ない状態。
+
+---
+
+## Phase 3: User Story 1 - 検索エンジン経由でランキングページに到達する (Priority: P1) 🎯 MVP
+
+**Goal**: SEO 基盤(sitemap / robots / canonical / hreflang / og:locale / soft-404 防止)を整えて Google にインデックスさせる。spec.md SC-006 の達成。
+
+**Independent Test**: quickstart.md Phase 1 の `curl` 検証コマンドが全て期待値を返し、GSC で sitemap 提出ステータスが「成功」になり、Indexed URLs ≥ 500 になる。
+
+### Implementation for User Story 1
+
+- [ ] T005 [P] [US1] `typescript/app/sitemap.ts` と `typescript/lib/sitemap-data.ts` を新規作成し、静的ページ + 全企業 + 全業界 + 全市場(両ロケール)の URL を `MetadataRoute.Sitemap` で返す。`lastModified` / `changeFrequency` / `priority` / `alternates.languages` は contracts/sitemap-shape.md §3 に従う。`export const revalidate = 86400`。存在しない企業 ID は `listSecurityCodes()` の戻り値で除外(FR-007b)
+- [ ] T006 [P] [US1] `typescript/app/robots.ts` を新規作成し、`MetadataRoute.Robots` で `User-agent: *` / `Allow: /` / `Disallow: /*?q=*` / `Disallow: /*?sortType=*` / `Sitemap: $NEXT_PUBLIC_SITE_URL/sitemap.xml` を出力(contracts/url-routes.md §7)
+- [ ] T007 [P] [US1] `typescript/public/og/default-ja.png` および `typescript/public/og/default-en.png`(1200×630)を追加(静的 OGP フォールバック)
+- [ ] T008 [US1] `typescript/app/[lang]/layout.tsx` を修正し、(1) `og:locale` を `lang` から動的に切替(`ja` → `ja_JP`、`en` → `en_US`、FR-003)、(2) `hreflang` alternates を `lib/seo.ts` 経由で出力、(3) `<JsonLd>` で `Organization` + `WebSite` を埋め込み、(4) 既定 OGP として T007 の `default-ja.png` / `default-en.png` を `openGraph.images` に指定する。依存: T002, T003, T007
+- [ ] T009 [P] [US1] `typescript/app/[lang]/companies/[id]/page.tsx` を修正し、(1) `getCompany` が `notFound` 相当の応答なら `notFound()` を呼ぶ(FR-007b)、(2) `generateMetadata` で `lib/seo.ts` 経由の canonical + hreflang を出力、(3) 既存の `<head>` ハードコードを除去。依存: T002
+- [ ] T010 [P] [US1] `typescript/app/[lang]/companies/page.tsx`(企業リスト)を修正し、`generateMetadata` で canonical(クエリ無視) + hreflang を出力。依存: T002
+- [ ] T011 [P] [US1] `typescript/app/[lang]/industries/[id]/page.tsx` を修正し、存在しない `id` は `notFound()`、canonical + hreflang を出力。依存: T002
+- [ ] T012 [P] [US1] `typescript/app/[lang]/markets/[id]/page.tsx` を修正し、存在しない `id` は `notFound()`、canonical + hreflang を出力。依存: T002
+- [ ] T013 [US1] **GSC 操作(OPS)**: 本番デプロイ後に Search Console → Sitemaps で `sitemap.xml` を提出し、主要 20 URL を URL Inspection で手動インデックス申請。PR ではなく運用タスク(quickstart.md Phase 1)。依存: T005–T012 が本番デプロイ済み
+
+**Checkpoint** (SC-006): sitemap 提出「成功」、GSC Indexed URLs ≥ 500、canonical / hreflang / og:locale が主要ページで正しい。実 MAU が 200–300 へ伸び始める。
+
+---
+
+## Phase 4: User Story 2 - ランキングページから関連ページを回遊する (Priority: P2)
+
+**Goal**: 構造化データ・関連企業・並び順タブ・動的 OGP・データ更新日バッジで内部回遊と SERP リッチ化を実現する。spec.md SC-007 の達成。
+
+**Independent Test**: Google Rich Results Test で `Corporation` schema 検出、`/ja/industries/{id}/salary` が 200 OK で `<title>` に「平均年収」を含む、企業詳細ページ下部に同業界 / 同市場 TOP5 が表示、`/ja/companies/{id}/opengraph-image` が PNG を返す。
+
+### 内部リンク / バッジ用のプリミティブ(新規ファイル群)
+
+- [ ] T014 [P] [US2] `typescript/components/DataFreshnessBadge.tsx` を新規作成(`fiscalYear` + `updatedAt` を H1 直下に表示、CLS を避ける固定高さ。FR-014a / data-model.md §7)
+- [ ] T015 [P] [US2] `typescript/components/SortTypeTabs.tsx` を新規作成(path-segment ベースの 4 タブ、現在のタブを `aria-current="page"`。FR-012 / data-model.md §4)
+- [ ] T016 [P] [US2] `typescript/components/RelatedCompanies.tsx` を新規作成(同業界 TOP5 + 同市場 TOP5、SSR で初期 HTML に含める、CLS 0)。FR-011
+- [ ] T017 [P] [US2] `typescript/components/ShareButtons.tsx` を新規作成(X intent + はてブ。`'use client'` は不要、`<a target="_blank">` のみ)。FR-014
+- [ ] T018 [P] [US2] `typescript/lib/sort-type.ts` を新規作成し `SORT_TYPES` const と `SortType` 型を export。`typescript/dictionaries/ja.json` / `en.json` に `sortType.{slug}` の表示語(平均年収 / 営業利益 / 自己資本比率 等)を追記。data-model.md §4 / contracts/url-routes.md §2
+
+### 既存ページへの統合(JSON-LD + バッジ + 関連企業)
+
+- [ ] T019 [US2] `typescript/app/[lang]/companies/[id]/page.tsx` に `<JsonLd>` で `Corporation` + `BreadcrumbList` を出力、`<DataFreshnessBadge>` を H1 直下、`<RelatedCompanies>` を本文下部、`<ShareButtons>` をサイドバー/末尾に挿入。FR-008 / FR-011 / FR-014 / FR-014a。依存: T003, T009, T014, T016, T017
+- [ ] T020 [US2] `typescript/app/[lang]/industries/[id]/page.tsx` に `<JsonLd>` で `ItemList` + `BreadcrumbList` + `CollectionPage`、`<DataFreshnessBadge>`、`<SortTypeTabs current="net_sales">` を挿入し、`export const revalidate = 3600`。FR-008 / FR-009 / FR-014a。依存: T003, T011, T014, T015
+- [ ] T021 [US2] `typescript/app/[lang]/markets/[id]/page.tsx` に同様の構造化データ + バッジ + タブ + ISR を適用。FR-008 / FR-009 / FR-014a。依存: T003, T012, T014, T015
+
+### 並び順 path-tab ルート(新規)
+
+- [ ] T022 [US2] `typescript/app/[lang]/industries/[id]/[sortType]/page.tsx` を新規作成。`generateStaticParams` で `SORT_TYPES` の `salary` / `op-income` / `equity` の 3 値に限定列挙(`net_sales` は親ルート canonical へ)。`<title>` に並び順語を含める(FR-013)。canonical は self、`net_sales` を踏んだ場合は親 URL に redirect or 404。ISR 1h。依存: T002, T011, T015, T018
+- [ ] T023 [US2] `typescript/app/[lang]/markets/[id]/[sortType]/page.tsx` を新規作成(T022 と同じ規約で market 用)。依存: T002, T012, T015, T018
+- [ ] T024 [US2] `typescript/lib/sitemap-data.ts` を更新し、業界 × sortType 3 値 と 市場 × sortType 3 値 のエントリを追加(contracts/sitemap-shape.md §3.3 / §3.4)。依存: T005, T022, T023
+
+### 動的 OGP 画像(Edge Runtime)
+
+- [ ] T025 [P] [US2] `typescript/app/[lang]/companies/[id]/opengraph-image.tsx` を新規作成。1200×630、企業名 / 証券コード / 売上 / 業界を表示。FR-010。依存: T004
+- [ ] T026 [P] [US2] `typescript/app/[lang]/industries/[id]/opengraph-image.tsx` を新規作成(業界名 + 企業数)。FR-010。依存: T004
+- [ ] T027 [P] [US2] `typescript/app/[lang]/markets/[id]/opengraph-image.tsx` を新規作成(市場名 + 企業数)。FR-010。依存: T004
+
+**Checkpoint** (SC-007): Rich Results Test で `Corporation` 検出、4 種並び順 path-tab が 200、関連企業セクション表示、動的 OGP 画像 200、データ更新日バッジ表示、実 MAU 200–300。
+
+---
+
+## Phase 5: User Story 3 - 検索意図特化のハブページに直接ランディングする (Priority: P3)
+
+**Goal**: ランキングハブ + 比較ページ + トップページ強化で、ロングテール検索意図を獲得する。spec.md SC-008 の達成。
+
+**Independent Test**: 20–30 ハブ URL が 200 OK、各ハブで Lighthouse SEO ≥ 95、ハブ本文に固有数値文 3 文以上、比較ページの上位 200 ペアが prebuilt、トップに TOP10 + ファクトイド + ハブティーザー。
+
+### ハブ / ファクトイドのプリミティブ
+
+- [ ] T028 [P] [US3] `typescript/lib/ranking-hubs.ts` を新規作成し、初期 20–30 スラッグの静的マップ(`slug` / `sortType` / `industryId?` / `marketId?` / `titleJa` / `introJa` / `topNCompanies`)を定義(data-model.md §5 / contracts/url-routes.md §3)
+- [ ] T029 [P] [US3] `typescript/lib/factoids.ts` を新規作成し、決定論的に「1 位 / 上位 5 社合計シェア / YoY 成長 / 中央値」等の固有数値文を生成する関数群を実装(research.md R-8 / FR-016 の anti-thin-content 要件 ≥ 3 文)
+
+### 新規ルート
+
+- [ ] T030 [US3] `typescript/app/[lang]/rankings/[slug]/page.tsx` を新規作成。`generateStaticParams` で `ranking-hubs.ts` のスラッグに限定。800 字以上のコメンタリ(導入 + H2 + 数値固有文 ≥ 3) + ランキングテーブル + パンくず + `<JsonLd>` `ItemList` + 関連リンク ≥ 5。SSG + `revalidate=86400`。FR-015 / FR-016。依存: T002, T003, T028, T029
+- [ ] T031 [US3] `typescript/app/[lang]/compare/[idA]/[idB]/page.tsx` を新規作成。`generateStaticParams` で上位 200 ペア(同業界 × 売上規模近接)を事前生成、`dynamicParams = true` + `revalidate=86400` で on-demand ISR。canonical は `idA < idB` に正規化。FR-017 / research.md R-5。依存: T002, T003
+- [ ] T032 [US3] `typescript/app/[lang]/page.tsx`(トップ)を修正し、ファーストビューに(1) 売上 TOP10 ミニテーブル、(2)「今日の発見」ファクトイド、(3) ランキングハブ 3 件のティーザーを追加。FR-018。依存: T028, T029
+
+### sitemap 反映
+
+- [ ] T033 [US3] `typescript/lib/sitemap-data.ts` を更新し、ランキングハブ全件 + 比較ページ prebuilt 200 ペアを sitemap エントリに追加。FR-019 / contracts/sitemap-shape.md §3.6 / §3.7。依存: T024, T030, T031
+
+**Checkpoint** (SC-008): 30+ ハブ Indexed、5+ ハブが GSC TOP30 内 impression、累計実 MAU 400–600、Lighthouse SEO ≥ 95 / Perf ≥ 80。
+
+---
+
+## Phase 6: User Story 4 - 外部メディアからの被リンク・流入を獲得する (Priority: P3)
+
+**Goal**: Hatenablog / Qiita-Zenn / X を通じた Referral と被リンクの獲得。spec.md SC-005 の達成。
+
+**Independent Test**: GA4 Referral で `hatenablog.jp` 月間 ≥ 50、GSC 被リンクレポートに新規外部ドメイン反映。
+
+> **本フェーズはコード変更を必要としない運用タスク**(コード側のシェア導線は T017 で完了済み)。PR は発生しないため OPS タスクとして列挙する。
+
+- [ ] OPS-005 [US4] Hatenablog 週 2 本ペースの長文記事を 12 週継続(FR-020)
+- [ ] OPS-006 [US4] Qiita または Zenn に技術記事 1 本以上を投稿(FR-021)
+- [ ] OPS-007 [US4] X で週 2–3 投稿(OGP カードを活用、FR-022)
+
+**Checkpoint**: SC-005(Hatenablog 経由 ≥ 50/月)、SC-004(GSC Indexed 4,000+ / TOP10 クエリ 50+)へ寄与。
+
+---
+
+## Phase 7: Polish & Cross-Cutting Concerns (Phase 4 of roadmap)
+
+**Purpose**: 複利化と最終最適化。各タスクは独立 PR として実装可能。
+
+- [ ] T034 [P] 業界 overview ルート `typescript/app/[lang]/industries/[id]/overview/page.tsx` を新規作成(1,500 字コメンタリ + 主要プレイヤー + 埋込ミニランキング、ISR 24h)。FR-025。依存: T011, T028, T029
+- [ ] T035 [P] `typescript/lib/sitemap-data.ts` に業界 overview エントリを追加(両ロケール × 33 業界 = 66 件)。FR-019。依存: T033, T034
+- [ ] T036 [P] `typescript/lib/ranking-hubs.ts` を 80–100 スラッグまで拡張(業界別年収 / 利益率 / YoY 成長率)。FR-024。依存: T028
+- [ ] T037 `typescript/app/sitemap.ts` を `generateSitemaps()` ベースの sitemap index 形式へ移行(URL 数が 10,000 を超えた時点でのみ実施、`sitemap-companies.xml` / `sitemap-rankings.xml` 等に分割)。FR-026。依存: T033, T035, T036
+- [ ] T038 [P] [OPS] GSC「impressions あり / CTR 低」クエリの週次抽出と `<title>` / `description` 最適化(年号・規模表記・「最新版」フックを含める)。FR-023。週次オペレーション、コード変更は対象ページの `generateMetadata` 内コピー修正のみ
+- [ ] T039 [P] [OPS] Top 5 ページの Lighthouse mobile スコアを週次計測し、80 を下回ったら改善 PR を起こす。FR-027 / SC-009
+- [ ] T040 [P] 既存 `typescript/lib/SortTypes.tsx`(query-string ベースのレガシー UI)を T015 の `components/SortTypeTabs.tsx` で完全置換し、レガシーコンポーネントを削除する(FR-002 の `?sortType=*` Disallow と整合させる)。依存: T015, T022, T023
+- [ ] T041 quickstart.md の Phase 1–4 検証コマンドを一通り通過することを確認する最終チェック PR(変更が無ければ checklist の文書更新のみ)
+
+**Final Checkpoint** (SC-001 / SC-009): 実 MAU ≥ 1,000、Indexed ≥ 4,000、平均セッション ≥ 40s、ページ/セッション ≥ 2.5、LCP ≤ 2.5s / INP ≤ 200ms / CLS ≤ 0.1、Bot 割合 < 30%。
+
+---
+
+## Dependencies & Execution Order
+
+### Phase Dependencies
+
+```
+Phase 0 (OPS) ──┐
+                ├── Phase 1 (T001) ── Phase 2 (T002, T003, T004 [P])
+                                          │
+                                          ├── Phase 3 (US1)
+                                          ├── Phase 4 (US2)   ← Phase 3 のページ修正がマージ後に着手
+                                          ├── Phase 5 (US3)   ← Phase 4 と並行可
+                                          └── Phase 6 (US4) [OPS のみ、いつでも開始可]
+                                                  │
+                                                  └── Phase 7 (Polish)
+```
+
+- **Phase 0 (OPS)** は計測の前提のため即時開始。コードフェーズと並行可。
+- **Phase 1 (T001)** がマージされるまで Phase 2 を本番デプロイしてはいけない(metadataBase が間違ったホストで吐かれる)。
+- **Phase 2 (T002–T004)** の 3 タスクは互いに独立で `[P]`。3 つ全てマージ後に Phase 3+ の実装タスクが安定して進められる。
+- **Phase 3 (US1)** は MVP。SC-006 達成までこの 8 PR(T005–T012)を最優先で揃える。T013 は本番反映後の運用タスク。
+- **Phase 4 (US2)** は Phase 3 のページ修正(T009–T012)をベースに重ねるため、対象ページの先行 PR がマージされた後で個別 PR を起こす。
+- **Phase 5 (US3)** は Phase 4 のコンポーネント(`SortTypeTabs` / `RelatedCompanies` / `DataFreshnessBadge`)を直接は使わないため、Phase 4 と並行で進められる(担当者が分かれる場合)。ただし `sitemap-data.ts` 更新(T033)は T024 と直列。
+- **Phase 7** は Phase 5 完了後に着手。T037(sitemap index 化)は URL 数が 10k を超えてから。
+
+### Task-level Dependencies (要点)
+
+| Task | 依存する完了済みタスク | 触るファイル(主) |
+|------|-----------------------|------------------|
+| T001 | — | `.env_sample`, `compose.yaml`, `app/[lang]/layout.tsx` |
+| T002 | T001 | `lib/seo.ts`(新規) |
+| T003 | — | `components/JsonLd.tsx`(新規) |
+| T004 | — | `lib/og-image.tsx`(新規), `public/fonts/*` |
+| T005 | T002 | `app/sitemap.ts`, `lib/sitemap-data.ts`(新規) |
+| T006 | T001 | `app/robots.ts`(新規) |
+| T007 | — | `public/og/default-*.png`(新規) |
+| T008 | T002, T003, T007 | `app/[lang]/layout.tsx` |
+| T009 | T002 | `app/[lang]/companies/[id]/page.tsx` |
+| T010 | T002 | `app/[lang]/companies/page.tsx` |
+| T011 | T002 | `app/[lang]/industries/[id]/page.tsx` |
+| T012 | T002 | `app/[lang]/markets/[id]/page.tsx` |
+| T013 | T005–T012 本番デプロイ済 | (OPS) |
+| T014–T017 | — | 各新規コンポーネント |
+| T018 | — | `lib/sort-type.ts`(新規), `dictionaries/*.json` |
+| T019 | T003, T009, T014, T016, T017 | `app/[lang]/companies/[id]/page.tsx` |
+| T020 | T003, T011, T014, T015 | `app/[lang]/industries/[id]/page.tsx` |
+| T021 | T003, T012, T014, T015 | `app/[lang]/markets/[id]/page.tsx` |
+| T022 | T002, T011, T015, T018 | `app/[lang]/industries/[id]/[sortType]/page.tsx`(新規) |
+| T023 | T002, T012, T015, T018 | `app/[lang]/markets/[id]/[sortType]/page.tsx`(新規) |
+| T024 | T005, T022, T023 | `lib/sitemap-data.ts` |
+| T025 | T004 | `app/[lang]/companies/[id]/opengraph-image.tsx`(新規) |
+| T026 | T004 | `app/[lang]/industries/[id]/opengraph-image.tsx`(新規) |
+| T027 | T004 | `app/[lang]/markets/[id]/opengraph-image.tsx`(新規) |
+| T028 | — | `lib/ranking-hubs.ts`(新規) |
+| T029 | — | `lib/factoids.ts`(新規) |
+| T030 | T002, T003, T028, T029 | `app/[lang]/rankings/[slug]/page.tsx`(新規) |
+| T031 | T002, T003 | `app/[lang]/compare/[idA]/[idB]/page.tsx`(新規) |
+| T032 | T028, T029 | `app/[lang]/page.tsx` |
+| T033 | T024, T030, T031 | `lib/sitemap-data.ts` |
+| T034 | T011, T028, T029 | `app/[lang]/industries/[id]/overview/page.tsx`(新規) |
+| T035 | T033, T034 | `lib/sitemap-data.ts` |
+| T036 | T028 | `lib/ranking-hubs.ts` |
+| T037 | T033, T035, T036 | `app/sitemap.ts` |
+| T040 | T015, T022, T023 | `lib/SortTypes.tsx`(削除) + 参照箇所 |
+
+### Parallel Opportunities(担当者を分けたい場合)
+
+- **Phase 2 内**: T002 / T003 / T004 を 3 並列で実装可
+- **Phase 3 内**: T005(sitemap)/ T006(robots)/ T007(OGP assets)/ T009–T012(各ページ修正)は別ファイルなので最大 7 並列
+- **Phase 4 内のプリミティブ**: T014 / T015 / T016 / T017 / T018 / T025 / T026 / T027 は最大 8 並列(`opengraph-image.tsx` は別エンドポイント)
+- **Phase 4 のページ統合**: T019 / T020 / T021 は別ページなので 3 並列。ただし依存タスク(T014–T017)が先行マージ必要
+- **Phase 4 の並び順タブ**: T022 / T023 は 2 並列
+- **Phase 5 のプリミティブ**: T028 / T029 は 2 並列
+- **Phase 5 のページ**: T030 / T031 / T032 は別ファイルで 3 並列
+- **Phase 7**: T034 / T036 / T038 / T039 / T040 は別ファイル/別運用なので並列可
+
+### Within Each User Story
+
+- 共通プリミティブ(コンポーネント / lib モジュール)→ それを使うページの統合 → sitemap への反映、の順で積み上げる
+- 1 PR の差分が大きくなりそうな場合(例: T019 で `companies/[id]/page.tsx` が 200 行超になる)は、JSON-LD と関連企業セクションを別 PR に分割して構わない
+
+---
+
+## Parallel Example: Phase 3 (US1) を 2 人で進める場合
+
+```text
+Developer A の PR ブランチ群(直列):
+  feat/T001-metadata-base
+  → feat/T002-lib-seo
+  → feat/T005-sitemap
+  → feat/T008-layout-hreflang
+
+Developer B の PR ブランチ群(直列、T002 マージ後):
+  feat/T003-jsonld-component (T002 と並行可)
+  → feat/T009-company-detail-canonical
+  → feat/T010-companies-list-canonical
+  → feat/T011-industry-canonical
+  → feat/T012-market-canonical
+
+並行スレッド(いつでも):
+  feat/T006-robots (T001 後)
+  feat/T007-default-og-assets
+```
+
+8 PR が概ね 1–2 週間で揃い、Phase 1 (Week 1–2) の目標(sitemap 提出 + Indexed ≥ 500)に到達する想定。
+
+---
+
+## Implementation Strategy
+
+### MVP First (User Story 1 Only) — Week 1–2
+
+1. Phase 0(OPS-001 〜 OPS-004)を着手と同時に進行
+2. Phase 1(T001)→ Phase 2(T002–T004)
+3. Phase 3(T005–T012)を順次 PR 化、本番デプロイ
+4. T013 で GSC sitemap 提出 + 主要 URL Inspection
+5. **STOP & VALIDATE**: quickstart.md Phase 1 セクションのコマンドを全て通過、GSC 「成功」を確認
+6. SC-006 達成を確認してから Phase 4 へ
+
+### Incremental Delivery — Week 3–8
+
+1. Phase 4(US2)を Week 3–4 で完了 → SC-007(実 MAU 200–300、Rich Results 検出)
+2. Phase 5(US3)を Week 5–8 で完了 → SC-008(30+ ハブ Indexed、実 MAU 400–600)
+3. Phase 6(US4 / OPS)は Week 3 から並走して継続
+
+### Parallel Team Strategy
+
+工数 1 人 × 15h/週(plan.md 制約)なので原則 1 人運用。ただし Hatenablog 執筆(OPS-005)は週末に分離するのが現実的。OPS タスクと PR タスクを同時並行で進める。
+
+### 工数不足時の削減優先順位(plan.md より)
+
+1. 比較ページ(T031)を後ろ倒し
+2. EN コンテンツの追加分は対象外のまま据え置き
+3. OGP 動的画像(T025–T027)を後ろ倒し(静的 default で運用)
+
+---
+
+## Notes
+
+- **`[P]` の判定基準**: (a) 触るファイルが他タスクと重ならない、(b) 依存先タスクが全てマージ済み、の AND 条件
+- **PR 本文テンプレ**: quickstart.md 末尾「共通: PR チェックリスト」を必ず本文に貼り付ける
+- **`make typescript/lint` / `npm run build` のいずれかが失敗した状態の PR は merge しない**(Constitution IV)
+- **手動確認が必要なページが多いタスク**(T020 / T021 など)は、PR 本文に確認した URL を箇条書きで列挙する
+- **生成コード**(`typescript/client/**`)を編集する PR は自動的に reject(Constitution III)
+- **Go / Ruby / OpenAPI を触る差分**が紛れ込んでいたら、その PR は本フィーチャー外のため別 PR に切り出す(Constitution I / II)


### PR DESCRIPTION
## Summary

- Translates the 4-phase MAU 1000 growth plan in `docs/mau-1000-roadmap.md` into a Spec Kit feature specification
- Defines 4 prioritized user stories, 27 functional requirements grouped by phase (SEO foundation → page quality → content hubs → optimization), and 10 measurable success criteria
- Documents 9 assumptions (MAU definition with engagement filter, JP-first scope, no paid ads, ~15h/week solo budget, etc.) and 7 edge cases (bot influx, doorway-page risk, indexing gaps)
- Stacked on top of #879 (`specify-init`); merge that first

## Files

- `specs/001-mau-1000-roadmap/spec.md` — the specification
- `specs/001-mau-1000-roadmap/checklists/requirements.md` — quality checklist (all items pass, no `[NEEDS CLARIFICATION]` markers)
- `.specify/feature.json` — feature directory pointer for downstream Spec Kit commands

## Next steps

- `/speckit-plan` to produce the implementation plan and technical design
- `/speckit-tasks` to break the plan into actionable, dependency-ordered tasks

## Test plan

- [ ] Confirm `specs/001-mau-1000-roadmap/spec.md` renders correctly on GitHub
- [ ] Confirm checklist items reflect the spec content
- [ ] No code changes — no build/test required

🤖 Generated with [Claude Code](https://claude.com/claude-code)